### PR TITLE
feat(footer): show current session name next to cwd

### DIFF
--- a/extensions/open-tui/config.ts
+++ b/extensions/open-tui/config.ts
@@ -9,6 +9,7 @@ export type { IconMode } from "./icons.ts";
 
 export interface FooterSegments {
 	cwd: boolean;
+	sessionName: boolean;
 	gitBranch: boolean;
 	gitStatus: boolean;
 	gitCommit: boolean;
@@ -47,6 +48,7 @@ export const DEFAULT_CONFIG: OpenTuiConfig = {
 	},
 	footerSegments: {
 		cwd: true,
+		sessionName: true,
 		gitBranch: true,
 		gitStatus: true,
 		gitCommit: false,

--- a/extensions/open-tui/footer.ts
+++ b/extensions/open-tui/footer.ts
@@ -221,6 +221,15 @@ export function installFooter(
 						priority: 0,
 					});
 				}
+				if (segments.sessionName) {
+					const sessionName = ctx.sessionManager.getSessionName();
+					if (sessionName) {
+						leftParts.push({
+							text: `${theme.fg("dim", glyphs.session)} ${theme.fg("text", truncateToWidth(sessionName, 24, theme.fg("dim", "...")))}`,
+							priority: 0,
+						});
+					}
+				}
 				const gitSeg = renderGitSegment(theme, state.git, glyphs, segments);
 				if (gitSeg) leftParts.push({ text: gitSeg, priority: 3 });
 				if (segments.runtime) {

--- a/extensions/open-tui/icons.ts
+++ b/extensions/open-tui/icons.ts
@@ -2,6 +2,7 @@ export type IconMode = "auto" | "nerd" | "ascii";
 
 export interface IconGlyphs {
 	cwd: string;
+	session: string;
 	git: string;
 	working: string;
 	done: string;
@@ -30,6 +31,7 @@ export interface IconGlyphs {
 
 const NERD_GLYPHS: IconGlyphs = {
 	cwd: "",
+	session: "",
 	git: "",
 	working: "",
 	done: "",
@@ -62,6 +64,7 @@ const NERD_GLYPHS: IconGlyphs = {
 // avoid collisions with the git-status set {= S ! A ? r x ^ v}.
 const ASCII_GLYPHS: IconGlyphs = {
 	cwd: "@",
+	session: "s",
 	git: "*",
 	working: "o",
 	done: "+",

--- a/tests/footer.test.ts
+++ b/tests/footer.test.ts
@@ -19,6 +19,7 @@ const theme = {
 test("both icon modes provide every footer semantic", () => {
 	const keys = [
 		"cwd",
+		"session",
 		"git",
 		"working",
 		"done",
@@ -68,6 +69,7 @@ test("ASCII footer renders icons as semantic labels", () => {
 		sessionManager: {
 			getCwd: () => "C:\\work\\project",
 			getEntries: () => entries,
+			getSessionName: () => undefined,
 		},
 		getContextUsage: () => ({ tokens: 250, contextWindow: 1_000, percent: 25 }),
 	} as unknown as ExtensionContext;
@@ -129,4 +131,92 @@ test("ASCII footer renders icons as semantic labels", () => {
 	assert.equal(hiddenOutput.length, 2);
 	assert.doesNotMatch(hiddenOutput.join("\n"), /goal active/);
 	assert.equal(extensionStatusReads, 1);
+});
+
+function renderFooterWithSession(opts: {
+	sessionName?: string | null;
+	mode?: "nerd" | "ascii";
+	sessionNameEnabled?: boolean;
+	width?: number;
+}): string {
+	const {
+		sessionName,
+		mode = "ascii",
+		sessionNameEnabled = true,
+		width = 160,
+	} = opts;
+	const name = sessionName === undefined ? "test-session" : sessionName;
+	let footerFactory: NonNullable<Parameters<ExtensionContext["ui"]["setFooter"]>[0]> | undefined;
+	const ctx = {
+		model: { provider: "openai", contextWindow: 1_000 },
+		ui: {
+			setFooter(factory: typeof footerFactory) {
+				footerFactory = factory;
+			},
+		},
+		sessionManager: {
+			getCwd: () => "/work/project",
+			getEntries: () => [],
+			getSessionName: () => name,
+		},
+		getContextUsage: () => ({ tokens: 0, contextWindow: 1_000, percent: 0 }),
+	} as unknown as ExtensionContext;
+	const config = structuredClone(DEFAULT_CONFIG);
+	config.icons.mode = mode;
+	config.footerSegments.sessionName = sessionNameEnabled;
+	const state: FooterState = {
+		git: emptyGitStatus(),
+		runtime: null,
+		sessionStartEpoch: Date.now(),
+		workingSince: undefined,
+		lastDoneIn: undefined,
+	};
+	installFooter(
+		ctx,
+		() => state,
+		() => config,
+		() => ({ provider: "OpenAI", model: "gpt-5", effort: "off" }),
+		{ setRequestRender() {}, scheduleGitRefresh() {} },
+	);
+	assert.ok(footerFactory);
+	const footerData = {
+		onBranchChange: () => () => {},
+		getExtensionStatuses: () => new Map(),
+	} as unknown as ReadonlyFooterDataProvider;
+	const component = footerFactory(
+		{ requestRender() {} } as TUI,
+		theme,
+		footerData,
+	) as Component;
+	return component.render(width).join("\n");
+}
+
+test("footer shows session name next to cwd when set", () => {
+	const out = renderFooterWithSession({ sessionName: "my-session" });
+	assert.ok(out.includes("my-session"), `missing session name\n${out}`);
+});
+
+test("footer hides session name when getSessionName returns empty", () => {
+	const out = renderFooterWithSession({ sessionName: null });
+	assert.ok(!out.includes("test-session"), `should not render name\n${out}`);
+});
+
+test("footer hides session name when footerSegments.sessionName is false", () => {
+	const out = renderFooterWithSession({ sessionName: "my-session", sessionNameEnabled: false });
+	assert.ok(!out.includes("my-session"), `should be hidden when disabled\n${out}`);
+});
+
+test("footer truncates long session names to 24 width units", () => {
+	const longName = "x".repeat(60);
+	const out = renderFooterWithSession({ sessionName: longName, width: 200 });
+	const clean = out.replace(/\x1b\[[0-9;]*m/g, "");
+	assert.ok(!clean.includes(longName), "full name must not appear\n" + clean);
+	assert.match(clean, /x{10,}\.\.\./, "truncated name should keep a prefix and ellipsis\n" + clean);
+});
+
+test("session name uses matching glyph in nerd and ascii modes", () => {
+	const asciiOut = renderFooterWithSession({ mode: "ascii", sessionName: "sess" });
+	assert.ok(asciiOut.includes(resolveGlyphs("ascii").session), `ascii glyph missing\n${asciiOut}`);
+	const nerdOut = renderFooterWithSession({ mode: "nerd", sessionName: "sess" });
+	assert.ok(nerdOut.includes(resolveGlyphs("nerd").session), `nerd glyph missing\n${nerdOut}`);
 });


### PR DESCRIPTION
Closes #2

## What

Shows the current pi **session name** in the footer's left line, right after the cwd segment:

```
📁 ~/projects/foo  🏷️ my-session-name  ⚙️ node  ● working 0:42 ...
```

- Reads the session name via `ctx.sessionManager.getSessionName()` (available since pi 0.80+)
- Hidden entirely when the session has no name — no placeholder, no wasted space
- New config toggle `footerSegments.sessionName` (default `true`) so it can be turned off
- Truncated at 24 chars with an ellipsis; same truncation priority as cwd when the line is full

## Why

With multiple concurrent sessions it's hard to tell which conversation is active just from the cwd (same directory, different topics). The session name makes the footer instantly recognizable, and matches how sessions are listed in `/sessions`.

## Files changed

- `extensions/open-tui/icons.ts` — add `session` glyph (nerd: tag, ascii: `s`)
- `extensions/open-tui/config.ts` — add `footerSegments.sessionName` (default `true`)
- `extensions/open-tui/footer.ts` — render session name segment after cwd

## Screenshot

(works locally, screenshot from user's terminal available on request)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 页脚现可显示当前会话名称，默认启用。
  * 会话名称为空时不会显示，过长名称将自动截断。
  * 支持 Nerd Font 和 ASCII 两种会话图标样式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->