### PR TITLE
Improve footer rendering on narrow terminals

### DIFF
--- a/extensions/open-tui/footer.ts
+++ b/extensions/open-tui/footer.ts
@@ -218,7 +218,8 @@ export function installFooter(
 					const maxCwd = Math.min(30, Math.max(10, Math.floor(width * 0.4)));
 					leftParts.push({
 						text: `${theme.fg("mdLink", glyphs.cwd)} ${theme.fg("accent", truncatePath(formatCwd(ctx.sessionManager.getCwd()), maxCwd))}`,
-						priority: 0,
+						// Keep the project directory visible longer than metadata segments.
+						priority: 4,
 					});
 				}
 				const gitSeg = renderGitSegment(theme, state.git, glyphs, segments);

--- a/extensions/open-tui/footer.ts
+++ b/extensions/open-tui/footer.ts
@@ -7,6 +7,7 @@ import type { GitStatus } from "./git.ts";
 import type { RuntimeInfo } from "./runtime.ts";
 import {
 	alignRight,
+	basenamePath,
 	cacheHitColor,
 	effortColor,
 	fitSegmentsByPriority,
@@ -17,6 +18,7 @@ import {
 	providerColor,
 	sanitizeStatus,
 	stressColor,
+	truncateBranch,
 	truncatePath,
 } from "./utils.ts";
 import type { FooterState, ModelMeta, UsageTotals } from "./state.ts";
@@ -41,13 +43,15 @@ function renderGitSegment(
 	git: GitStatus,
 	glyphs: IconGlyphs,
 	segments: OpenTuiConfig["footerSegments"],
-	maxBranchLen = 20,
+	maxBranchLen: number,
 ): string {
 	const parts: string[] = [];
 	if (segments.gitBranch) {
 		if (git.branch) {
 			parts.push(theme.fg("mdLink", glyphs.git));
-			parts.push(theme.fg("mdLink", truncatePath(git.branch, maxBranchLen)));
+			// Bound this only by the total footer width; the priority fitter below
+			// applies the actual available width when other segments need space.
+			parts.push(theme.fg("mdLink", truncateBranch(git.branch, maxBranchLen)));
 		} else if (git.commit?.detached) {
 			parts.push(theme.fg("warning", glyphs.git));
 			parts.push(theme.fg("warning", "HEAD"));
@@ -213,23 +217,39 @@ export function installFooter(
 
 				const totals = getUsageTotals(ctx);
 
-				const leftParts: { text: string; priority: number }[] = [];
+				const leftParts: {
+					text: string;
+					priority: number;
+					compactText?: string;
+					truncate?: (text: string, maxWidth: number, ellipsis: string) => string;
+				}[] = [];
 				if (segments.cwd) {
+					const cwd = formatCwd(ctx.sessionManager.getCwd());
 					const maxCwd = Math.min(30, Math.max(10, Math.floor(width * 0.4)));
+					const cwdPrefix = `${theme.fg("mdLink", glyphs.cwd)} `;
+					const cwdText = `${cwdPrefix}${theme.fg("accent", truncatePath(cwd, maxCwd))}`;
+					const cwdBasename = `${cwdPrefix}${theme.fg("accent", truncatePath(basenamePath(cwd), maxCwd))}`;
 					leftParts.push({
-						text: `${theme.fg("mdLink", glyphs.cwd)} ${theme.fg("accent", truncatePath(formatCwd(ctx.sessionManager.getCwd()), maxCwd))}`,
-						// Keep the project directory visible longer than metadata segments.
+						text: cwdText,
+						compactText: cwdBasename,
+						truncate: (_text, maxWidth, ellipsis) => {
+							const pathWidth = maxWidth - visibleWidth(cwdPrefix);
+							if (pathWidth <= 0) return truncateToWidth(cwdPrefix, maxWidth, ellipsis);
+							return `${cwdPrefix}${theme.fg("accent", truncatePath(basenamePath(cwd), pathWidth))}`;
+						},
+						// Higher priorities survive longer: keep the cwd basename, then
+						// reduce runtime, branch/status, and finally the timer.
 						priority: 4,
 					});
 				}
-				const gitSeg = renderGitSegment(theme, state.git, glyphs, segments);
-				if (gitSeg) leftParts.push({ text: gitSeg, priority: 3 });
+				const gitSeg = renderGitSegment(theme, state.git, glyphs, segments, width);
+				if (gitSeg) leftParts.push({ text: gitSeg, priority: 2 });
 				if (segments.runtime) {
 					const runtimeSeg = renderRuntimeSegment(theme, state.runtime, config.icons.mode);
 					if (runtimeSeg) leftParts.push({ text: runtimeSeg, priority: 1 });
 				}
 				const timerSeg = renderTimerSegment(theme, state, glyphs);
-				if (timerSeg) leftParts.push({ text: timerSeg, priority: 2 });
+				if (timerSeg) leftParts.push({ text: timerSeg, priority: 3 });
 
 				let rightBlock = "";
 				if (segments.context) {

--- a/extensions/open-tui/utils.ts
+++ b/extensions/open-tui/utils.ts
@@ -24,19 +24,28 @@ export function formatCwd(cwd: string): string {
 	return rel === "" ? "~" : `~${sep}${rel}`;
 }
 
+export function basenamePath(path: string): string {
+	return path.split(/[\\/]/).filter(Boolean).at(-1) ?? path;
+}
+
 export function truncatePath(path: string, maxLen: number): string {
 	if (path.length <= maxLen) return path;
 	if (maxLen <= 3) return "...".slice(0, maxLen);
 
 	// The basename is the useful part of a cwd. Keep it intact before spending
 	// space on parent directories.
-	const sepChar = path.includes("/") ? "/" : "\\";
-	const basename = path.split(/[\\/]/).filter(Boolean).at(-1) ?? "";
-	const suffix = `${sepChar}${basename}`;
-	if (suffix.length + 3 <= maxLen) return `...${suffix}`;
+	const basename = basenamePath(path);
+	if (basename.length <= maxLen) return basename;
 
 	// If even the basename does not fit, show as much of its end as possible.
 	return `...${basename.slice(-(maxLen - 3))}`;
+}
+
+/** Truncate branch names from the end so the branch's prefix remains visible. */
+export function truncateBranch(branch: string, maxLen: number): string {
+	if (branch.length <= maxLen) return branch;
+	if (maxLen <= 3) return "...".slice(0, maxLen);
+	return `${branch.slice(0, maxLen - 3)}...`;
 }
 
 export function fmtTokens(n: number): string {
@@ -88,24 +97,47 @@ export function alignRight(left: string, right: string, width: number, theme: Th
 export type PrioritizedSegment = {
 	text: string;
 	priority: number;
+	/** Optional compact form used before lower-priority segments are shrunk. */
+	compactText?: string;
+	/** Optional segment-aware truncation, used when a generic prefix is not useful. */
+	truncate?: (text: string, maxWidth: number, ellipsis: string) => string;
 };
 
 /**
- * Pack segments into maxWidth, shrinking/dropping lowest-priority segments first.
- * Higher priority = survives longer. Returns the surviving segment texts in
- * original order, space-joined. Each segment is either kept whole, truncated
- * with ellipsis, or dropped entirely.
+ * Pack segments into maxWidth, compacting segments first and then
+ * shrinking/dropping lowest-priority segments. Higher priority = survives
+ * longer. Returns the surviving segment texts in original order, space-joined.
+ * Each segment is either kept whole, compacted, truncated with ellipsis, or
+ * dropped entirely.
  */
 export function fitSegmentsByPriority(
 	segs: readonly PrioritizedSegment[],
 	maxW: number,
 	ellipsis = "...",
 ): string[] {
-	const items = segs.map((s) => ({ text: s.text, priority: s.priority, w: visibleWidth(s.text) }));
+	const items = segs.map((s) => ({
+		text: s.text,
+		compactText: s.compactText,
+		priority: s.priority,
+		truncate: s.truncate,
+		w: visibleWidth(s.text),
+	}));
 	const totalW = () => {
 		const active = items.filter((it) => it.text !== "");
 		return active.reduce((a, it) => a + it.w, 0) + Math.max(0, active.length - 1);
 	};
+
+	// Compact in display order before sacrificing any segment content. This is
+	// used by the footer to discard cwd parents while keeping the basename.
+	if (totalW() > maxW) {
+		for (const item of items) {
+			if (!item.compactText || visibleWidth(item.compactText) >= item.w) continue;
+			item.text = item.compactText;
+			item.w = visibleWidth(item.text);
+			if (totalW() <= maxW) break;
+		}
+	}
+
 	while (totalW() > maxW) {
 		let target = -1;
 		for (let i = 0; i < items.length; i++) {
@@ -121,7 +153,10 @@ export function fitSegmentsByPriority(
 			items[target].text = "";
 			items[target].w = 0;
 		} else if (avail < items[target].w) {
-			items[target].text = truncateToWidth(items[target].text, avail, ellipsis);
+			const truncate = items[target].truncate;
+			items[target].text = truncate
+				? truncate(items[target].text, avail, ellipsis)
+				: truncateToWidth(items[target].text, avail, ellipsis);
 			items[target].w = visibleWidth(items[target].text);
 		} else {
 			break;

--- a/extensions/open-tui/utils.ts
+++ b/extensions/open-tui/utils.ts
@@ -27,21 +27,16 @@ export function formatCwd(cwd: string): string {
 export function truncatePath(path: string, maxLen: number): string {
 	if (path.length <= maxLen) return path;
 	if (maxLen <= 3) return "...".slice(0, maxLen);
+
+	// The basename is the useful part of a cwd. Keep it intact before spending
+	// space on parent directories.
 	const sepChar = path.includes("/") ? "/" : "\\";
-	const parts = path.split(/[\\/]/);
-	if (parts.length <= 2) return path.slice(0, maxLen - 3) + "...";
-	// Keep first segment (e.g. ~) and as many trailing segments as fit.
-	const tail: string[] = [];
-	let tailLen = 0;
-	for (let i = parts.length - 1; i >= 1; i--) {
-		const seg = parts[i]!;
-		if (tailLen + seg.length + 4 > maxLen) break;
-		tail.unshift(seg);
-		tailLen += seg.length + 1;
-	}
-	const head = parts[0]!;
-	const result = `${head}${sepChar}...${sepChar}${tail.join(sepChar)}`;
-	return result.length > maxLen ? result.slice(0, maxLen - 3) + "..." : result;
+	const basename = path.split(/[\\/]/).filter(Boolean).at(-1) ?? "";
+	const suffix = `${sepChar}${basename}`;
+	if (suffix.length + 3 <= maxLen) return `...${suffix}`;
+
+	// If even the basename does not fit, show as much of its end as possible.
+	return `...${basename.slice(-(maxLen - 3))}`;
 }
 
 export function fmtTokens(n: number): string {

--- a/tests/footer.test.ts
+++ b/tests/footer.test.ts
@@ -11,16 +11,34 @@ import { installFooter } from "../extensions/open-tui/footer.ts";
 import { emptyGitStatus } from "../extensions/open-tui/git.ts";
 import { resolveGlyphs } from "../extensions/open-tui/icons.ts";
 import type { FooterState } from "../extensions/open-tui/state.ts";
-import { truncatePath } from "../extensions/open-tui/utils.ts";
+import { fitSegmentsByPriority, truncateBranch, truncatePath } from "../extensions/open-tui/utils.ts";
 
 const theme = {
 	fg: (_color: string, text: string) => text,
 } as Theme;
 
+test("branch truncation preserves the branch prefix", () => {
+	assert.equal(truncateBranch("fix/cwd-footer-truncation", 20), "fix/cwd-footer-tr...");
+});
+
 test("cwd truncation preserves the basename", () => {
-	assert.equal(truncatePath("~/projects/pi-open-tui", 14), ".../pi-open-tui");
+	assert.equal(truncatePath("~/projects/pi-open-tui", 14), "pi-open-tui");
 	assert.equal(truncatePath("~/projects/pi-open-tui", 9), "...en-tui");
-	assert.equal(truncatePath("C:\\work\\project", 11), "...\\project");
+	assert.equal(truncatePath("C:\\work\\project", 11), "project");
+});
+
+test("footer compacts cwd before truncating runtime and branch", () => {
+	assert.deepEqual(
+		fitSegmentsByPriority(
+			[
+				{ text: "@ ~/projects/pi-open-tui", compactText: "@ pi-open-tui", priority: 4 },
+				{ text: "* fix/cwd-footer-truncation", priority: 2 },
+				{ text: "node 24.6.0", priority: 1 },
+			],
+			53,
+		),
+		["@ pi-open-tui", "* fix/cwd-footer-truncation", "node 24.6.0"],
+	);
 });
 
 test("both icon modes provide every footer semantic", () => {
@@ -81,7 +99,7 @@ test("ASCII footer renders icons as semantic labels", () => {
 	const config = structuredClone(DEFAULT_CONFIG);
 	config.icons.mode = "ascii";
 	const state: FooterState = {
-		git: { ...emptyGitStatus(), branch: "main", modified: 2 },
+		git: { ...emptyGitStatus(), branch: "fix/cwd-footer-truncation", modified: 2 },
 		runtime: { name: "nodejs", version: "24.6.0" },
 		sessionStartEpoch: Date.now(),
 		workingSince: Date.now() - 2_000,
@@ -114,7 +132,7 @@ test("ASCII footer renders icons as semantic labels", () => {
 
 	for (const expected of [
 		"@",
-		"* main",
+		"* fix/cwd-footer-truncation",
 		"!2",
 		"node 24.6.0",
 		"o working",

--- a/tests/footer.test.ts
+++ b/tests/footer.test.ts
@@ -11,10 +11,17 @@ import { installFooter } from "../extensions/open-tui/footer.ts";
 import { emptyGitStatus } from "../extensions/open-tui/git.ts";
 import { resolveGlyphs } from "../extensions/open-tui/icons.ts";
 import type { FooterState } from "../extensions/open-tui/state.ts";
+import { truncatePath } from "../extensions/open-tui/utils.ts";
 
 const theme = {
 	fg: (_color: string, text: string) => text,
 } as Theme;
+
+test("cwd truncation preserves the basename", () => {
+	assert.equal(truncatePath("~/projects/pi-open-tui", 14), ".../pi-open-tui");
+	assert.equal(truncatePath("~/projects/pi-open-tui", 9), "...en-tui");
+	assert.equal(truncatePath("C:\\work\\project", 11), "...\\project");
+});
 
 test("both icon modes provide every footer semantic", () => {
 	const keys = [


### PR DESCRIPTION
   ## Summary

   Improve footer rendering on narrow terminals so important project context remains visible. Usecase is using the mobile phone to ssh into the pi-machine.

   ## Changes

   - Preserve the current working directory basename when space is limited.
   - Truncate Git branch names from the end so prefixes like `fix/` and `feature/`
 remain visible.
   - Compact footer segments before truncating or removing them.
   - Prioritize the cwd and timer over lower-priority runtime and Git metadata.
   - Add regression tests for path truncation, branch truncation, and narrow footer
 layouts.

   ## Testing

   - `npm test` — 26 tests passed
   
   ## Authored

  Written by GPT 5.6 Luna Max

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化页脚信息在有限空间下的显示效果。
  * 工作目录路径优先保留最后一级目录，Git 分支名称采用更合理的截断方式。
  * 根据可用宽度和信息优先级动态压缩页脚内容，提升关键信息的可见性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->