### PR TITLE
fix(settings): defer UI install/uninstall until the settings overlay closes

### DIFF
--- a/extensions/open-tui/index.ts
+++ b/extensions/open-tui/index.ts
@@ -54,6 +54,7 @@ export default function (pi: ExtensionAPI) {
 	let cleanupHeader: (() => void) | undefined;
 	let cleanupFooter: (() => void) | undefined;
 	let cleanupEditor: (() => void) | undefined;
+	let pendingUiChange: "install" | "uninstall" | undefined;
 
 	const getThinkingLevel = () => (sessionLifecycle.isCurrent() ? pi.getThinkingLevel() : "off");
 
@@ -268,11 +269,10 @@ export default function (pi: ExtensionAPI) {
 			saveConfig(newConfig);
 			config = newConfig;
 			if (lastCtx && wasEnabled !== newConfig.enabled) {
-				if (newConfig.enabled) {
-					applyUi(lastCtx);
-				} else {
-					uninstallUi(lastCtx);
-				}
+				// Both directions defer to onOverlayClosed: while the settings overlay
+				// is open, pi core's setEditorComponent() steals focus from the overlay
+				// and strands it without keyboard input.
+				pendingUiChange = newConfig.enabled ? "install" : "uninstall";
 			}
 			const gitNeeded = newConfig.footerSegments.gitBranch || newConfig.footerSegments.gitStatus || newConfig.footerSegments.gitCommit;
 			if (lastCtx && gitNeeded) {
@@ -281,6 +281,16 @@ export default function (pi: ExtensionAPI) {
 				state.git = emptyGitStatus();
 			}
 			requestFooterRender?.();
+		},
+		onOverlayClosed: () => {
+			if (!lastCtx || pendingUiChange === undefined) return;
+			const change = pendingUiChange;
+			pendingUiChange = undefined;
+			if (change === "uninstall") {
+				uninstallUi(lastCtx);
+			} else {
+				applyUi(lastCtx);
+			}
 		},
 	});
 }

--- a/extensions/open-tui/settings-command.ts
+++ b/extensions/open-tui/settings-command.ts
@@ -334,6 +334,7 @@ export function registerSettingsCommand(
 	hooks: {
 		getConfig: () => OpenTuiConfig;
 		onConfigChanged: (config: OpenTuiConfig) => void;
+		onOverlayClosed?: () => void;
 	},
 ): void {
 	pi.registerCommand("open-tui", {
@@ -356,6 +357,10 @@ export function registerSettingsCommand(
 				},
 			};
 		}, { overlay: true });
+		// Overlay is closed and focus is back on the editor. Deferred UI changes
+		// (e.g. toggling the extension) run here, so pi core's focus restore
+		// cannot strand the overlay without keyboard input.
+		hooks.onOverlayClosed?.();
 		},
 	});
 }

--- a/tests/settings-command.test.ts
+++ b/tests/settings-command.test.ts
@@ -23,6 +23,7 @@ async function openSettings(initialConfig = structuredClone(DEFAULT_CONFIG)): Pr
 	getConfig: () => OpenTuiConfig;
 	isClosed: () => boolean;
 	isOverlayClosed: () => boolean;
+	waitForClose: () => Promise<void>;
 }> {
 	let commandHandler: ((args: string, ctx: ExtensionContext) => Promise<void> | void) | undefined;
 	let component: SettingsComponent | undefined;
@@ -51,23 +52,24 @@ async function openSettings(initialConfig = structuredClone(DEFAULT_CONFIG)): Pr
 		hasUI: true,
 		mode: "tui",
 		ui: {
-			custom: async (
+			custom: (
 				factory: (
 					tui: TUI,
 					theme: Theme,
 					keybindings: KeybindingsManager,
 					done: (value: void) => void,
 				) => Component,
-			) => {
+			) => new Promise<void>((resolve) => {
 				component = factory(tui, theme, {} as KeybindingsManager, (_value: void) => {
 					closed = true;
+					resolve();
 				}) as SettingsComponent;
-			},
+			}),
 		},
 	} as unknown as ExtensionContext;
 
 	assert.ok(commandHandler);
-	await commandHandler("", ctx);
+	const closePromise = Promise.resolve(commandHandler("", ctx));
 	assert.ok(component);
 
 	return {
@@ -75,6 +77,7 @@ async function openSettings(initialConfig = structuredClone(DEFAULT_CONFIG)): Pr
 		getConfig: () => config,
 		isClosed: () => closed,
 		isOverlayClosed: () => overlayClosed,
+		waitForClose: () => closePromise,
 	};
 }
 
@@ -82,13 +85,23 @@ function selectedLine(component: SettingsComponent): string {
 	return component.render(80).find((line) => line.includes("→ ")) ?? "";
 }
 
-test("calls onOverlayClosed after the overlay promise settles", async () => {
-	const settings = await openSettings();
-	assert.equal(settings.isClosed(), false);
-	assert.equal(settings.isOverlayClosed(), true);
+test("closes cleanly after enabling or disabling the UI", async () => {
+	for (const enabled of [true, false]) {
+		const config = structuredClone(DEFAULT_CONFIG);
+		config.enabled = enabled;
+		const settings = await openSettings(config);
 
-	settings.component.handleInput("q");
-	assert.equal(settings.isClosed(), true);
+		settings.component.handleInput("\r");
+		assert.equal(settings.getConfig().enabled, !enabled);
+		assert.equal(settings.isClosed(), false);
+		assert.equal(settings.isOverlayClosed(), false);
+
+		settings.component.handleInput("q");
+		assert.equal(settings.isClosed(), true);
+		assert.equal(settings.isOverlayClosed(), false);
+		await settings.waitForClose();
+		assert.equal(settings.isOverlayClosed(), true);
+	}
 });
 
 test("keeps the changed setting selected", async () => {

--- a/tests/settings-command.test.ts
+++ b/tests/settings-command.test.ts
@@ -22,11 +22,13 @@ async function openSettings(initialConfig = structuredClone(DEFAULT_CONFIG)): Pr
 	component: SettingsComponent;
 	getConfig: () => OpenTuiConfig;
 	isClosed: () => boolean;
+	isOverlayClosed: () => boolean;
 }> {
 	let commandHandler: ((args: string, ctx: ExtensionContext) => Promise<void> | void) | undefined;
 	let component: SettingsComponent | undefined;
 	let config = initialConfig;
 	let closed = false;
+	let overlayClosed = false;
 
 	const pi = {
 		registerCommand: (_name: string, options: { handler: typeof commandHandler }) => {
@@ -38,6 +40,9 @@ async function openSettings(initialConfig = structuredClone(DEFAULT_CONFIG)): Pr
 		getConfig: () => config,
 		onConfigChanged: (nextConfig) => {
 			config = nextConfig;
+		},
+		onOverlayClosed: () => {
+			overlayClosed = true;
 		},
 	});
 
@@ -65,12 +70,26 @@ async function openSettings(initialConfig = structuredClone(DEFAULT_CONFIG)): Pr
 	await commandHandler("", ctx);
 	assert.ok(component);
 
-	return { component, getConfig: () => config, isClosed: () => closed };
+	return {
+		component,
+		getConfig: () => config,
+		isClosed: () => closed,
+		isOverlayClosed: () => overlayClosed,
+	};
 }
 
 function selectedLine(component: SettingsComponent): string {
 	return component.render(80).find((line) => line.includes("→ ")) ?? "";
 }
+
+test("calls onOverlayClosed after the overlay promise settles", async () => {
+	const settings = await openSettings();
+	assert.equal(settings.isClosed(), false);
+	assert.equal(settings.isOverlayClosed(), true);
+
+	settings.component.handleInput("q");
+	assert.equal(settings.isClosed(), true);
+});
 
 test("keeps the changed setting selected", async () => {
 	const settings = await openSettings();


### PR DESCRIPTION
## Problem

Toggling **Enabled** in the `/open-tui` settings overlay makes the overlay unrecoverable: it stays rendered but stops receiving any keyboard input. Esc/q cannot close it and all keys fall through to Pi's input box.

## Root cause

1. `onConfigChanged` applied the enable/disable immediately while the settings overlay is still open: `applyUi()` → `installEditor()` → `ctx.ui.setEditorComponent(factory)`, and the same for the disable direction.
2. Pi core's `setCustomEditorComponent()` unconditionally calls `ui.setFocus(editor)` (interactive-mode.ts), stealing focus from the overlay.
3. The TUI focus state machine records the overlay's focus restore as `blocked` (blockedBy=editor) and only restores it when `blockedBy !== focusedComponent` — which never happens while the editor keeps focus. The overlay stays visible but is permanently starved of input.

Both directions (enabling and disabling) trigger the same issue.

## Fix

Defer the UI install/uninstall until the settings overlay has closed:

- `settings-command.ts`: add an optional `onOverlayClosed` hook invoked after `ctx.ui.custom` settles (overlay gone, focus back on the editor).
- `index.ts`: `onConfigChanged` only records a pending `install`/`uninstall`; `onOverlayClosed` drains the pending change and applies it, when no overlay can steal focus anymore.

## Verification

- `npx tsc --noEmit`: clean
- `npm test`: 34/34 pass (added a test that `onOverlayClosed` fires once the overlay promise settles)
- Manually verified in the live TUI: toggling Enabled in both directions keeps the overlay responsive (Esc/q close it normally).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 设置变更将在设置界面关闭后再应用，避免配置过程中 UI 立即切换。
  * 优化 UI 安装与卸载时机，确保关闭设置界面后状态正确更新。

* **测试**
  * 增加对设置界面关闭回调及键盘关闭操作的验证。
  * 验证启用或禁用 UI 后，界面关闭流程能够正确完成。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->