### PR TITLE
feat: add configurable editor cursor styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A polished TUI for [Pi](https://pi.dev) coding agent. Combines the best of pi-ha
 - **Working timer** — live elapsed time while the agent is working, done duration when finished
 - **Turn telemetry** — generation speed, TTFT, stalls, tokens, and list-price rate after each complete agent run
 - **Zero prototype patches** — uses public Pi APIs (setHeader/setFooter/setEditorComponent), safe across Pi updates
-- **Interactive settings UI** — `/open-tui` opens a tabbed settings dialog (General / Icons / Footer / Telemetry)
+- **Interactive settings UI** — `/open-tui` opens a tabbed settings dialog (General / Appearance / Footer / Telemetry)
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Run `/open-tui` to open the interactive settings UI. Configuration is stored at 
 {
   "enabled": true,
   "settingsLanguage": "en",
+  "cursorStyle": "block",
   "icons": {
     "mode": "auto"
   },
@@ -64,6 +65,7 @@ Run `/open-tui` to open the interactive settings UI. Configuration is stored at 
 ```
 
 - `settingsLanguage`: language for the `/open-tui` settings UI only; `en` or `zh`
+- `cursorStyle`: editor cursor style; `block` (default), `bar`, or `underline`. The latter two use the terminal's hardware cursor and require a terminal that supports cursor-shape escape sequences.
 - `icons.mode`: `auto` (detect Nerd Font), `nerd` (force Nerd Font glyphs), or `ascii` (plain fallbacks)
 - `footerSegments.sessionName`: shows the current session name next to cwd (off by default); hidden when the session has no name
 - `footerSegments.gitCommit`: shows short hash + tag on detached HEAD (off by default)

--- a/extensions/open-tui/config.ts
+++ b/extensions/open-tui/config.ts
@@ -4,6 +4,7 @@ import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import type { IconMode } from "./icons.ts";
 
 export type SettingsLanguage = "en" | "zh";
+export type CursorStyle = "block" | "bar" | "underline";
 
 export type { IconMode } from "./icons.ts";
 
@@ -33,6 +34,7 @@ export interface TelemetryConfig {
 export interface OpenTuiConfig {
 	enabled: boolean;
 	settingsLanguage: SettingsLanguage;
+	cursorStyle: CursorStyle;
 	icons: {
 		mode: IconMode;
 	};
@@ -43,6 +45,7 @@ export interface OpenTuiConfig {
 export const DEFAULT_CONFIG: OpenTuiConfig = {
 	enabled: true,
 	settingsLanguage: "en",
+	cursorStyle: "block",
 	icons: {
 		mode: "auto",
 	},
@@ -121,6 +124,9 @@ export function loadConfig(notify?: (msg: string, level: "warning" | "info") => 
 		const config = deepMerge(DEFAULT_CONFIG, parsed);
 		if (config.settingsLanguage !== "en" && config.settingsLanguage !== "zh") {
 			config.settingsLanguage = DEFAULT_CONFIG.settingsLanguage;
+		}
+		if (config.cursorStyle !== "block" && config.cursorStyle !== "bar" && config.cursorStyle !== "underline") {
+			config.cursorStyle = DEFAULT_CONFIG.cursorStyle;
 		}
 		return config;
 	} catch (err) {

--- a/extensions/open-tui/editor.ts
+++ b/extensions/open-tui/editor.ts
@@ -5,7 +5,7 @@ import {
 	type KeybindingsManager,
 } from "@earendil-works/pi-coding-agent";
 import type { EditorTheme, TUI } from "@earendil-works/pi-tui";
-import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { CURSOR_MARKER, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { CursorStyle } from "./config.ts";
 import { findBottomBorderIndex, isEditorBorderLine, stripAnsi } from "./utils.ts";
 
@@ -21,8 +21,12 @@ const CURSOR_STYLE_SEQUENCES: Partial<Record<CursorStyle, string>> = {
 };
 const DEFAULT_CURSOR_STYLE_SEQUENCE = "\x1b[0 q";
 
-function removeSoftwareCursor(line: string): string {
-	return line.replace(/\x1b\[7m([\s\S]*?)\x1b\[0m/g, "$1");
+function removeSoftwareCursor(line: string, cursorMarker = ""): string {
+	return line.replace(/\x1b\[7m([\s\S]*?)\x1b\[0m/g, (_match, cursor: string) => {
+		const replacement = `${cursorMarker}${cursor}`;
+		cursorMarker = "";
+		return replacement;
+	});
 }
 
 function configureCursor(tui: TUI, cursorStyle: CursorStyle): void {
@@ -57,7 +61,8 @@ function roundedBorder(
 export class OpenTuiEditor extends CustomEditor {
 	private readonly getRail: () => string;
 	private readonly getBorder: (s: string) => string;
-	private readonly cursorStyle: CursorStyle;
+	private cursorStyle: CursorStyle;
+	private previewHardwareCursor = false;
 
 	constructor(
 		tui: TUI,
@@ -80,11 +85,34 @@ export class OpenTuiEditor extends CustomEditor {
 		super.setPaddingX(0);
 	}
 
+	setCursorStyle(cursorStyle: CursorStyle, blockHardwareCursor = false): void {
+		const styleChanged = cursorStyle !== this.cursorStyle;
+		this.previewHardwareCursor = cursorStyle !== "block";
+		this.cursorStyle = cursorStyle;
+		if (styleChanged) {
+			if (cursorStyle === "block") {
+				this.tui.terminal.write(DEFAULT_CURSOR_STYLE_SEQUENCE);
+				this.tui.setShowHardwareCursor(blockHardwareCursor);
+			} else {
+				configureCursor(this.tui, cursorStyle);
+			}
+		}
+		this.tui.requestRender();
+	}
+
 	private renderBase(width: number): string[] {
 		const renderedLines = super.render(width);
-		return this.cursorStyle === "block"
-			? renderedLines
-			: renderedLines.map(removeSoftwareCursor);
+		if (this.cursorStyle === "block") return renderedLines;
+
+		// A focused overlay suppresses the editor's cursor marker. Preserve its
+		// position only for the live settings preview, then clear it on refocus.
+		let cursorMarker = this.previewHardwareCursor && !this.focused ? CURSOR_MARKER : "";
+		if (this.focused) this.previewHardwareCursor = false;
+		return renderedLines.map((line) => {
+			const rendered = removeSoftwareCursor(line, cursorMarker);
+			if (rendered !== line) cursorMarker = "";
+			return rendered;
+		});
 	}
 
 	render(width: number): string[] {
@@ -123,20 +151,29 @@ export function installEditor(
 	_pi: ExtensionAPI,
 	ctx: ExtensionContext,
 	cursorStyle: CursorStyle = "block",
-): () => void {
+) {
 	let activeTui: TUI | undefined;
+	let activeEditor: OpenTuiEditor | undefined;
 	let previousHardwareCursor: boolean | undefined;
+	let currentCursorStyle = cursorStyle;
 
 	ctx.ui.setEditorComponent((tui, editorTheme, keybindings) => {
 		activeTui = tui;
 		previousHardwareCursor = tui.getShowHardwareCursor();
-		return new OpenTuiEditor(tui, editorTheme, keybindings, cursorStyle);
+		activeEditor = new OpenTuiEditor(tui, editorTheme, keybindings, currentCursorStyle);
+		return activeEditor;
 	});
-	return () => {
-		ctx.ui.setEditorComponent(undefined);
-		if (activeTui) {
-			if (cursorStyle !== "block") activeTui.terminal.write(DEFAULT_CURSOR_STYLE_SEQUENCE);
-			if (previousHardwareCursor !== undefined) activeTui.setShowHardwareCursor(previousHardwareCursor);
-		}
+	return {
+		setCursorStyle(nextCursorStyle: CursorStyle): void {
+			currentCursorStyle = nextCursorStyle;
+			activeEditor?.setCursorStyle(nextCursorStyle, previousHardwareCursor);
+		},
+		cleanup(): void {
+			ctx.ui.setEditorComponent(undefined);
+			if (activeTui) {
+				if (currentCursorStyle !== "block") activeTui.terminal.write(DEFAULT_CURSOR_STYLE_SEQUENCE);
+				if (previousHardwareCursor !== undefined) activeTui.setShowHardwareCursor(previousHardwareCursor);
+			}
+		},
 	};
 }

--- a/extensions/open-tui/editor.ts
+++ b/extensions/open-tui/editor.ts
@@ -19,15 +19,17 @@ const CURSOR_STYLE_SEQUENCES: Partial<Record<CursorStyle, string>> = {
 	bar: "\x1b[6 q",
 	underline: "\x1b[4 q",
 };
+const DEFAULT_CURSOR_STYLE_SEQUENCE = "\x1b[0 q";
 
 function removeSoftwareCursor(line: string): string {
 	return line.replace(/\x1b\[7m([\s\S]*?)\x1b\[0m/g, "$1");
 }
 
 function configureCursor(tui: TUI, cursorStyle: CursorStyle): void {
-	tui.setShowHardwareCursor?.(cursorStyle !== "block");
+	if (cursorStyle === "block") return;
+	tui.setShowHardwareCursor(true);
 	const sequence = CURSOR_STYLE_SEQUENCES[cursorStyle];
-	if (sequence) tui.terminal.write?.(sequence);
+	if (sequence) tui.terminal.write(sequence);
 }
 
 function roundedBorder(
@@ -127,13 +129,14 @@ export function installEditor(
 
 	ctx.ui.setEditorComponent((tui, editorTheme, keybindings) => {
 		activeTui = tui;
-		previousHardwareCursor = tui.getShowHardwareCursor?.();
+		previousHardwareCursor = tui.getShowHardwareCursor();
 		return new OpenTuiEditor(tui, editorTheme, keybindings, cursorStyle);
 	});
 	return () => {
 		ctx.ui.setEditorComponent(undefined);
-		if (activeTui && previousHardwareCursor !== undefined) {
-			activeTui.setShowHardwareCursor?.(previousHardwareCursor);
+		if (activeTui) {
+			if (cursorStyle !== "block") activeTui.terminal.write(DEFAULT_CURSOR_STYLE_SEQUENCE);
+			if (previousHardwareCursor !== undefined) activeTui.setShowHardwareCursor(previousHardwareCursor);
 		}
 	};
 }

--- a/extensions/open-tui/editor.ts
+++ b/extensions/open-tui/editor.ts
@@ -6,12 +6,28 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import type { EditorTheme, TUI } from "@earendil-works/pi-tui";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import type { CursorStyle } from "./config.ts";
 import { findBottomBorderIndex, isEditorBorderLine, stripAnsi } from "./utils.ts";
 
 function fillLine(content: string, width: number): string {
 	const truncated = truncateToWidth(content, Math.max(0, width), "");
 	const pad = " ".repeat(Math.max(0, width - visibleWidth(truncated)));
 	return `${truncated}${pad}`;
+}
+
+const CURSOR_STYLE_SEQUENCES: Partial<Record<CursorStyle, string>> = {
+	bar: "\x1b[6 q",
+	underline: "\x1b[4 q",
+};
+
+function removeSoftwareCursor(line: string): string {
+	return line.replace(/\x1b\[7m([\s\S]*?)\x1b\[0m/g, "$1");
+}
+
+function configureCursor(tui: TUI, cursorStyle: CursorStyle): void {
+	tui.setShowHardwareCursor?.(cursorStyle !== "block");
+	const sequence = CURSOR_STYLE_SEQUENCES[cursorStyle];
+	if (sequence) tui.terminal.write?.(sequence);
 }
 
 function roundedBorder(
@@ -39,13 +55,17 @@ function roundedBorder(
 export class OpenTuiEditor extends CustomEditor {
 	private readonly getRail: () => string;
 	private readonly getBorder: (s: string) => string;
+	private readonly cursorStyle: CursorStyle;
 
 	constructor(
 		tui: TUI,
 		editorTheme: EditorTheme,
 		keybindings: KeybindingsManager,
+		cursorStyle: CursorStyle = "block",
 	) {
 		super(tui, editorTheme, keybindings, { paddingX: 0 });
+		this.cursorStyle = cursorStyle;
+		configureCursor(tui, cursorStyle);
 		// ponytail: route the frame through this.borderColor so Pi can recolor it
 		// via updateEditorBorderColor() — bash mode ("! " prefix → green) and
 		// thinking-level borders both flow through this one property.
@@ -58,14 +78,21 @@ export class OpenTuiEditor extends CustomEditor {
 		super.setPaddingX(0);
 	}
 
+	private renderBase(width: number): string[] {
+		const renderedLines = super.render(width);
+		return this.cursorStyle === "block"
+			? renderedLines
+			: renderedLines.map(removeSoftwareCursor);
+	}
+
 	render(width: number): string[] {
-		if (width < 4) return super.render(width);
+		if (width < 4) return this.renderBase(width);
 
 		const rail = this.getRail();
 		const borderPaint = this.getBorder;
 		// ponytail: 1-char rail + 1-char gap on each side = 4 chars of chrome.
 		const innerWidth = Math.max(0, width - 4);
-		const baseLines = super.render(innerWidth);
+		const baseLines = this.renderBase(innerWidth);
 		const bottomIdx = findBottomBorderIndex(baseLines);
 
 		const result: string[] = [];
@@ -90,11 +117,23 @@ export class OpenTuiEditor extends CustomEditor {
 	}
 }
 
-export function installEditor(_pi: ExtensionAPI, ctx: ExtensionContext): () => void {
-	ctx.ui.setEditorComponent((tui, editorTheme, keybindings) =>
-		new OpenTuiEditor(tui, editorTheme, keybindings),
-	);
+export function installEditor(
+	_pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	cursorStyle: CursorStyle = "block",
+): () => void {
+	let activeTui: TUI | undefined;
+	let previousHardwareCursor: boolean | undefined;
+
+	ctx.ui.setEditorComponent((tui, editorTheme, keybindings) => {
+		activeTui = tui;
+		previousHardwareCursor = tui.getShowHardwareCursor?.();
+		return new OpenTuiEditor(tui, editorTheme, keybindings, cursorStyle);
+	});
 	return () => {
 		ctx.ui.setEditorComponent(undefined);
+		if (activeTui && previousHardwareCursor !== undefined) {
+			activeTui.setShowHardwareCursor?.(previousHardwareCursor);
+		}
 	};
 }

--- a/extensions/open-tui/index.ts
+++ b/extensions/open-tui/index.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { type OpenTuiConfig, DEFAULT_CONFIG, ensureConfigExists, loadConfig, saveConfig } from "./config.ts";
+import { type CursorStyle, type OpenTuiConfig, DEFAULT_CONFIG, ensureConfigExists, loadConfig, saveConfig } from "./config.ts";
 import { installEditor } from "./editor.ts";
 import { installFooter } from "./footer.ts";
 import { installHeader } from "./header.ts";
@@ -24,6 +24,23 @@ function isInteractiveLaunch(): boolean {
 		if (arg.startsWith("--mode")) return false;
 	}
 	return true;
+}
+
+type PendingUiChange = "install" | "uninstall" | "reinstall";
+
+export function getPendingUiChange(
+	wasEnabled: boolean,
+	enabled: boolean,
+	cursorStyle: CursorStyle,
+	active: boolean,
+	installedCursorStyle: CursorStyle | undefined,
+): PendingUiChange | undefined {
+	if (wasEnabled !== enabled) {
+		if (!enabled) return "uninstall";
+		return active && installedCursorStyle !== cursorStyle ? "reinstall" : "install";
+	}
+	if (enabled && active && installedCursorStyle !== cursorStyle) return "reinstall";
+	return undefined;
 }
 
 function clearVisibleScreen(): void {
@@ -54,7 +71,8 @@ export default function (pi: ExtensionAPI) {
 	let cleanupHeader: (() => void) | undefined;
 	let cleanupFooter: (() => void) | undefined;
 	let cleanupEditor: (() => void) | undefined;
-	let pendingUiChange: "install" | "uninstall" | "reinstall" | undefined;
+	let pendingUiChange: PendingUiChange | undefined;
+	let installedCursorStyle: CursorStyle | undefined;
 
 	const getThinkingLevel = () => (sessionLifecycle.isCurrent() ? pi.getThinkingLevel() : "off");
 
@@ -81,6 +99,7 @@ export default function (pi: ExtensionAPI) {
 				},
 			);
 			cleanupEditor = installEditor(pi, ctx, config.cursorStyle);
+			installedCursorStyle = config.cursorStyle;
 			active = true;
 		}
 	};
@@ -95,6 +114,7 @@ export default function (pi: ExtensionAPI) {
 			cleanupFooter = undefined;
 			cleanupEditor = undefined;
 			requestFooterRender = undefined;
+			installedCursorStyle = undefined;
 			active = false;
 		}
 	};
@@ -266,16 +286,21 @@ export default function (pi: ExtensionAPI) {
 		getConfig: () => config,
 		onConfigChanged: (newConfig) => {
 			const wasEnabled = config.enabled;
-			const cursorStyleChanged = config.cursorStyle !== newConfig.cursorStyle;
 			saveConfig(newConfig);
 			config = newConfig;
-			if (lastCtx && wasEnabled !== newConfig.enabled) {
-				// Both directions defer to onOverlayClosed: while the settings overlay
-				// is open, pi core's setEditorComponent() steals focus from the overlay
-				// and strands it without keyboard input.
-				pendingUiChange = newConfig.enabled ? "install" : "uninstall";
-			} else if (lastCtx && cursorStyleChanged && active) {
-				pendingUiChange = "reinstall";
+			if (lastCtx) {
+				const nextUiChange = getPendingUiChange(
+					wasEnabled,
+					newConfig.enabled,
+					newConfig.cursorStyle,
+					active,
+					installedCursorStyle,
+				);
+				if (wasEnabled !== newConfig.enabled) {
+					pendingUiChange = nextUiChange;
+				} else if (nextUiChange) {
+					pendingUiChange = nextUiChange;
+				}
 			}
 			const gitNeeded = newConfig.footerSegments.gitBranch || newConfig.footerSegments.gitStatus || newConfig.footerSegments.gitCommit;
 			if (lastCtx && gitNeeded) {
@@ -289,11 +314,12 @@ export default function (pi: ExtensionAPI) {
 			if (!lastCtx || pendingUiChange === undefined) return;
 			const change = pendingUiChange;
 			pendingUiChange = undefined;
-			if (change === "uninstall") {
+			if (!config.enabled || change === "uninstall") {
 				uninstallUi(lastCtx);
 			} else if (change === "reinstall") {
 				cleanupEditor?.();
 				cleanupEditor = installEditor(pi, lastCtx, config.cursorStyle);
+				installedCursorStyle = config.cursorStyle;
 			} else {
 				applyUi(lastCtx);
 			}

--- a/extensions/open-tui/index.ts
+++ b/extensions/open-tui/index.ts
@@ -54,7 +54,7 @@ export default function (pi: ExtensionAPI) {
 	let cleanupHeader: (() => void) | undefined;
 	let cleanupFooter: (() => void) | undefined;
 	let cleanupEditor: (() => void) | undefined;
-	let pendingUiChange: "install" | "uninstall" | undefined;
+	let pendingUiChange: "install" | "uninstall" | "reinstall" | undefined;
 
 	const getThinkingLevel = () => (sessionLifecycle.isCurrent() ? pi.getThinkingLevel() : "off");
 
@@ -80,7 +80,7 @@ export default function (pi: ExtensionAPI) {
 					},
 				},
 			);
-			cleanupEditor = installEditor(pi, ctx);
+			cleanupEditor = installEditor(pi, ctx, config.cursorStyle);
 			active = true;
 		}
 	};
@@ -266,6 +266,7 @@ export default function (pi: ExtensionAPI) {
 		getConfig: () => config,
 		onConfigChanged: (newConfig) => {
 			const wasEnabled = config.enabled;
+			const cursorStyleChanged = config.cursorStyle !== newConfig.cursorStyle;
 			saveConfig(newConfig);
 			config = newConfig;
 			if (lastCtx && wasEnabled !== newConfig.enabled) {
@@ -273,6 +274,8 @@ export default function (pi: ExtensionAPI) {
 				// is open, pi core's setEditorComponent() steals focus from the overlay
 				// and strands it without keyboard input.
 				pendingUiChange = newConfig.enabled ? "install" : "uninstall";
+			} else if (lastCtx && cursorStyleChanged && active) {
+				pendingUiChange = "reinstall";
 			}
 			const gitNeeded = newConfig.footerSegments.gitBranch || newConfig.footerSegments.gitStatus || newConfig.footerSegments.gitCommit;
 			if (lastCtx && gitNeeded) {
@@ -288,6 +291,9 @@ export default function (pi: ExtensionAPI) {
 			pendingUiChange = undefined;
 			if (change === "uninstall") {
 				uninstallUi(lastCtx);
+			} else if (change === "reinstall") {
+				cleanupEditor?.();
+				cleanupEditor = installEditor(pi, lastCtx, config.cursorStyle);
 			} else {
 				applyUi(lastCtx);
 			}

--- a/extensions/open-tui/index.ts
+++ b/extensions/open-tui/index.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { type CursorStyle, type OpenTuiConfig, DEFAULT_CONFIG, ensureConfigExists, loadConfig, saveConfig } from "./config.ts";
+import { type OpenTuiConfig, DEFAULT_CONFIG, ensureConfigExists, loadConfig, saveConfig } from "./config.ts";
 import { installEditor } from "./editor.ts";
 import { installFooter } from "./footer.ts";
 import { installHeader } from "./header.ts";
@@ -26,21 +26,11 @@ function isInteractiveLaunch(): boolean {
 	return true;
 }
 
-type PendingUiChange = "install" | "uninstall" | "reinstall";
+type PendingUiChange = "install" | "uninstall";
 
-export function getPendingUiChange(
-	wasEnabled: boolean,
-	enabled: boolean,
-	cursorStyle: CursorStyle,
-	active: boolean,
-	installedCursorStyle: CursorStyle | undefined,
-): PendingUiChange | undefined {
-	if (wasEnabled !== enabled) {
-		if (!enabled) return "uninstall";
-		return active && installedCursorStyle !== cursorStyle ? "reinstall" : "install";
-	}
-	if (enabled && active && installedCursorStyle !== cursorStyle) return "reinstall";
-	return undefined;
+export function getPendingUiChange(enabled: boolean, active: boolean): PendingUiChange | undefined {
+	if (enabled === active) return undefined;
+	return enabled ? "install" : "uninstall";
 }
 
 function clearVisibleScreen(): void {
@@ -70,9 +60,8 @@ export default function (pi: ExtensionAPI) {
 	let workingTimer: ReturnType<typeof setInterval> | undefined;
 	let cleanupHeader: (() => void) | undefined;
 	let cleanupFooter: (() => void) | undefined;
-	let cleanupEditor: (() => void) | undefined;
+	let editor: ReturnType<typeof installEditor> | undefined;
 	let pendingUiChange: PendingUiChange | undefined;
-	let installedCursorStyle: CursorStyle | undefined;
 
 	const getThinkingLevel = () => (sessionLifecycle.isCurrent() ? pi.getThinkingLevel() : "off");
 
@@ -98,8 +87,7 @@ export default function (pi: ExtensionAPI) {
 					},
 				},
 			);
-			cleanupEditor = installEditor(pi, ctx, config.cursorStyle);
-			installedCursorStyle = config.cursorStyle;
+			editor = installEditor(pi, ctx, config.cursorStyle);
 			active = true;
 		}
 	};
@@ -109,12 +97,11 @@ export default function (pi: ExtensionAPI) {
 		if (active) {
 			cleanupHeader?.();
 			cleanupFooter?.();
-			cleanupEditor?.();
+			editor?.cleanup();
 			cleanupHeader = undefined;
 			cleanupFooter = undefined;
-			cleanupEditor = undefined;
+			editor = undefined;
 			requestFooterRender = undefined;
-			installedCursorStyle = undefined;
 			active = false;
 		}
 	};
@@ -285,22 +272,14 @@ export default function (pi: ExtensionAPI) {
 	registerSettingsCommand(pi, {
 		getConfig: () => config,
 		onConfigChanged: (newConfig) => {
-			const wasEnabled = config.enabled;
+			const cursorStyleChanged = config.cursorStyle !== newConfig.cursorStyle;
 			saveConfig(newConfig);
 			config = newConfig;
+			if (cursorStyleChanged && active && editor) {
+				editor.setCursorStyle(newConfig.cursorStyle);
+			}
 			if (lastCtx) {
-				const nextUiChange = getPendingUiChange(
-					wasEnabled,
-					newConfig.enabled,
-					newConfig.cursorStyle,
-					active,
-					installedCursorStyle,
-				);
-				if (wasEnabled !== newConfig.enabled) {
-					pendingUiChange = nextUiChange;
-				} else if (nextUiChange) {
-					pendingUiChange = nextUiChange;
-				}
+				pendingUiChange = getPendingUiChange(newConfig.enabled, active);
 			}
 			const gitNeeded = newConfig.footerSegments.gitBranch || newConfig.footerSegments.gitStatus || newConfig.footerSegments.gitCommit;
 			if (lastCtx && gitNeeded) {
@@ -316,10 +295,6 @@ export default function (pi: ExtensionAPI) {
 			pendingUiChange = undefined;
 			if (!config.enabled || change === "uninstall") {
 				uninstallUi(lastCtx);
-			} else if (change === "reinstall") {
-				cleanupEditor?.();
-				cleanupEditor = installEditor(pi, lastCtx, config.cursorStyle);
-				installedCursorStyle = config.cursorStyle;
 			} else {
 				applyUi(lastCtx);
 			}

--- a/extensions/open-tui/settings-command.ts
+++ b/extensions/open-tui/settings-command.ts
@@ -8,7 +8,7 @@ import {
 	type TUI,
 	Text,
 } from "@earendil-works/pi-tui";
-import type { IconMode, OpenTuiConfig, SettingsLanguage } from "./config.ts";
+import type { CursorStyle, IconMode, OpenTuiConfig, SettingsLanguage } from "./config.ts";
 
 interface SettingItem {
 	id: string;
@@ -28,6 +28,7 @@ const COPY = {
 		labels: {
 			enabled: "Enabled",
 			language: "Language",
+			cursorStyle: "Cursor style",
 			iconMode: "Icon mode",
 			cwd: "CWD",
 			sessionName: "Session name",
@@ -48,6 +49,7 @@ const COPY = {
 			on: "On",
 			off: "Off",
 			languages: { en: "English", zh: "简体中文" },
+			cursorStyles: { block: "Block", bar: "Bar", underline: "Underline" },
 			icons: { auto: "Auto", nerd: "Nerd", ascii: "ASCII" },
 		},
 	},
@@ -58,6 +60,7 @@ const COPY = {
 		labels: {
 			enabled: "启用",
 			language: "语言",
+			cursorStyle: "光标样式",
 			iconMode: "图标模式",
 			cwd: "当前目录",
 			sessionName: "会话名",
@@ -78,6 +81,7 @@ const COPY = {
 			on: "开启",
 			off: "关闭",
 			languages: { en: "English", zh: "简体中文" },
+			cursorStyles: { block: "块", bar: "竖线", underline: "下划线" },
 			icons: { auto: "自动", nerd: "Nerd", ascii: "ASCII" },
 		},
 	},
@@ -110,6 +114,13 @@ function toggleLanguage(config: OpenTuiConfig): OpenTuiConfig {
 	return { ...config, settingsLanguage: config.settingsLanguage === "en" ? "zh" : "en" };
 }
 
+function cycleCursorStyle(config: OpenTuiConfig): OpenTuiConfig {
+	const order: CursorStyle[] = ["block", "bar", "underline"];
+	const currentIdx = order.indexOf(config.cursorStyle);
+	const next = order[(currentIdx + 1) % order.length]!;
+	return { ...config, cursorStyle: next };
+}
+
 function toggleTelemetry(config: OpenTuiConfig, key: keyof OpenTuiConfig["telemetry"]): OpenTuiConfig {
 	return {
 		...config,
@@ -121,6 +132,7 @@ function buildFeaturesItems(config: OpenTuiConfig, copy: SettingsCopy): SettingI
 	return [
 		{ id: "enabled", label: copy.labels.enabled, currentValue: config.enabled ? copy.values.on : copy.values.off },
 		{ id: "settingsLanguage", label: copy.labels.language, currentValue: copy.values.languages[config.settingsLanguage] },
+		{ id: "cursorStyle", label: copy.labels.cursorStyle, currentValue: copy.values.cursorStyles[config.cursorStyle] },
 	];
 }
 
@@ -177,6 +189,7 @@ function handleSettingChange(
 	if (tab === "features") {
 		if (itemId === "enabled") return toggleEnabled(config);
 		if (itemId === "settingsLanguage") return toggleLanguage(config);
+		if (itemId === "cursorStyle") return cycleCursorStyle(config);
 	}
 	if (tab === "icons" && itemId === "mode") return cycleIconMode(config);
 	if (tab === "segments") {

--- a/extensions/open-tui/settings-command.ts
+++ b/extensions/open-tui/settings-command.ts
@@ -23,7 +23,7 @@ const TABS: Tab[] = ["features", "icons", "segments", "telemetry"];
 const COPY = {
 	en: {
 		title: "Open TUI Settings",
-		tabs: { features: "General", icons: "Icons", segments: "Footer", telemetry: "Telemetry" },
+		tabs: { features: "General", icons: "Appearance", segments: "Footer", telemetry: "Telemetry" },
 		hint: "Tab/Shift+Tab/←/→: tabs · ↑/↓: move · Enter/Space: change · Esc/q: close",
 		labels: {
 			enabled: "Enabled",
@@ -55,7 +55,7 @@ const COPY = {
 	},
 	zh: {
 		title: "Open TUI 设置",
-		tabs: { features: "常规", icons: "图标", segments: "Footer", telemetry: "遥测" },
+		tabs: { features: "常规", icons: "外观", segments: "Footer", telemetry: "遥测" },
 		hint: "Tab/Shift+Tab/←/→：切页 · ↑/↓：移动 · Enter/Space：更改 · Esc/q：关闭",
 		labels: {
 			enabled: "启用",
@@ -132,12 +132,14 @@ function buildFeaturesItems(config: OpenTuiConfig, copy: SettingsCopy): SettingI
 	return [
 		{ id: "enabled", label: copy.labels.enabled, currentValue: config.enabled ? copy.values.on : copy.values.off },
 		{ id: "settingsLanguage", label: copy.labels.language, currentValue: copy.values.languages[config.settingsLanguage] },
-		{ id: "cursorStyle", label: copy.labels.cursorStyle, currentValue: copy.values.cursorStyles[config.cursorStyle] },
 	];
 }
 
 function buildIconsItems(config: OpenTuiConfig, copy: SettingsCopy): SettingItem[] {
-	return [{ id: "mode", label: copy.labels.iconMode, currentValue: copy.values.icons[config.icons.mode] }];
+	return [
+		{ id: "mode", label: copy.labels.iconMode, currentValue: copy.values.icons[config.icons.mode] },
+		{ id: "cursorStyle", label: copy.labels.cursorStyle, currentValue: copy.values.cursorStyles[config.cursorStyle] },
+	];
 }
 
 function buildSegmentsItems(config: OpenTuiConfig, copy: SettingsCopy): SettingItem[] {
@@ -189,9 +191,11 @@ function handleSettingChange(
 	if (tab === "features") {
 		if (itemId === "enabled") return toggleEnabled(config);
 		if (itemId === "settingsLanguage") return toggleLanguage(config);
+	}
+	if (tab === "icons") {
+		if (itemId === "mode") return cycleIconMode(config);
 		if (itemId === "cursorStyle") return cycleCursorStyle(config);
 	}
-	if (tab === "icons" && itemId === "mode") return cycleIconMode(config);
 	if (tab === "segments") {
 		return toggleSetting(config, itemId as keyof OpenTuiConfig["footerSegments"]);
 	}

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { KeybindingsManager } from "@earendil-works/pi-coding-agent";
-import type { EditorTheme, TUI } from "@earendil-works/pi-tui";
+import { TUI, type EditorTheme, type Terminal } from "@earendil-works/pi-tui";
 import { installEditor, OpenTuiEditor } from "../extensions/open-tui/editor.ts";
 import { stripAnsi } from "../extensions/open-tui/utils.ts";
 
@@ -68,6 +68,43 @@ test("uses the terminal hardware cursor for non-block styles", () => {
 	}
 });
 
+test("shows a hardware cursor while previewing a non-block style under an overlay", () => {
+	const cursorEvents: string[] = [];
+	const terminal = {
+		columns: 80,
+		rows: 24,
+		kittyProtocolActive: false,
+		start() {},
+		stop() {},
+		write() {},
+		hideCursor: () => cursorEvents.push("hide"),
+		showCursor: () => cursorEvents.push("show"),
+	} as unknown as Terminal;
+	const overlayTui = new TUI(terminal, false);
+	const editor = new OpenTuiEditor(
+		overlayTui,
+		editorTheme,
+		{ matches: () => false } as unknown as KeybindingsManager,
+	);
+	overlayTui.addChild(editor);
+	overlayTui.setFocus(editor);
+	overlayTui.showOverlay({ render: () => ["settings"], invalidate() {} });
+	cursorEvents.length = 0;
+
+	editor.setCursorStyle("bar");
+	(overlayTui as unknown as { doRender(): void }).doRender();
+
+	assert.equal(cursorEvents.at(-1), "show");
+
+	overlayTui.hideOverlay();
+	(overlayTui as unknown as { doRender(): void }).doRender();
+	overlayTui.showOverlay({ render: () => ["other overlay"], invalidate() {} });
+	cursorEvents.length = 0;
+	(overlayTui as unknown as { doRender(): void }).doRender();
+	assert.equal(cursorEvents.at(-1), "hide");
+	overlayTui.stop();
+});
+
 test("preserves block hardware cursor settings", () => {
 	let changes = 0;
 	const hardwareTui = {
@@ -108,8 +145,8 @@ test("restores cursor shape and visibility when the editor is removed", () => {
 		},
 	} as unknown as import("@earendil-works/pi-coding-agent").ExtensionContext;
 
-	const cleanup = installEditor({} as import("@earendil-works/pi-coding-agent").ExtensionAPI, ctx, "bar");
-	cleanup();
+	const editor = installEditor({} as import("@earendil-works/pi-coding-agent").ExtensionAPI, ctx, "bar");
+	editor.cleanup();
 
 	assert.ok(writes.includes("\x1b[0 q"), "cursor shape was reset");
 	assert.deepEqual(visibility, [true, false]);

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -36,6 +36,38 @@ test("compensates Pi editor padding for the custom left rail", () => {
 	assert.equal(contentLine.indexOf("x"), 2);
 });
 
+test("uses the terminal hardware cursor for non-block styles", () => {
+	for (const [cursorStyle, sequence] of [
+		["bar", "\x1b[6 q"],
+		["underline", "\x1b[4 q"],
+	] as const) {
+		const writes: string[] = [];
+		let hardwareCursor: boolean | undefined;
+		const hardwareTui = {
+			...tui,
+			terminal: {
+				rows: 24,
+				write: (data: string) => writes.push(data),
+			},
+			setShowHardwareCursor: (enabled: boolean) => {
+				hardwareCursor = enabled;
+			},
+		} as unknown as TUI;
+		const editor = new OpenTuiEditor(
+			hardwareTui,
+			editorTheme,
+			{ matches: () => false } as unknown as KeybindingsManager,
+			cursorStyle,
+		);
+
+		const lines = editor.render(40);
+
+		assert.equal(hardwareCursor, true);
+		assert.ok(writes.includes(sequence), `${cursorStyle} cursor sequence was sent`);
+		assert.ok(lines.every((line) => !line.includes("\x1b[7m")), "software block cursor was removed");
+	}
+});
+
 test("frame recolors via borderColor (bash mode / thinking level hook)", () => {
 	let painted = "";
 	const theme = {

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { KeybindingsManager } from "@earendil-works/pi-coding-agent";
 import type { EditorTheme, TUI } from "@earendil-works/pi-tui";
-import { OpenTuiEditor } from "../extensions/open-tui/editor.ts";
+import { installEditor, OpenTuiEditor } from "../extensions/open-tui/editor.ts";
 import { stripAnsi } from "../extensions/open-tui/utils.ts";
 
 const tui = {
@@ -66,6 +66,53 @@ test("uses the terminal hardware cursor for non-block styles", () => {
 		assert.ok(writes.includes(sequence), `${cursorStyle} cursor sequence was sent`);
 		assert.ok(lines.every((line) => !line.includes("\x1b[7m")), "software block cursor was removed");
 	}
+});
+
+test("preserves block hardware cursor settings", () => {
+	let changes = 0;
+	const hardwareTui = {
+		...tui,
+		getShowHardwareCursor: () => true,
+		setShowHardwareCursor: () => changes++,
+	} as unknown as TUI;
+
+	new OpenTuiEditor(
+		hardwareTui,
+		editorTheme,
+		{ matches: () => false } as unknown as KeybindingsManager,
+		"block",
+	);
+
+	assert.equal(changes, 0);
+});
+
+test("restores cursor shape and visibility when the editor is removed", () => {
+	const writes: string[] = [];
+	const visibility: boolean[] = [];
+	const hardwareTui = {
+		...tui,
+		terminal: {
+			rows: 24,
+			write: (data: string) => writes.push(data),
+		},
+		getShowHardwareCursor: () => false,
+		setShowHardwareCursor: (enabled: boolean) => visibility.push(enabled),
+	} as unknown as TUI;
+	const ctx = {
+		ui: {
+			setEditorComponent: (factory: unknown) => {
+				if (typeof factory === "function") {
+					factory(hardwareTui, editorTheme, { matches: () => false });
+				}
+			},
+		},
+	} as unknown as import("@earendil-works/pi-coding-agent").ExtensionContext;
+
+	const cleanup = installEditor({} as import("@earendil-works/pi-coding-agent").ExtensionAPI, ctx, "bar");
+	cleanup();
+
+	assert.ok(writes.includes("\x1b[0 q"), "cursor shape was reset");
+	assert.deepEqual(visibility, [true, false]);
 });
 
 test("frame recolors via borderColor (bash mode / thinking level hook)", () => {

--- a/tests/settings-command.test.ts
+++ b/tests/settings-command.test.ts
@@ -104,6 +104,17 @@ test("closes cleanly after enabling or disabling the UI", async () => {
 	}
 });
 
+test("cycles cursor style from the General tab", async () => {
+	const settings = await openSettings();
+
+	settings.component.handleInput("\x1b[B");
+	settings.component.handleInput("\x1b[B");
+	settings.component.handleInput("\r");
+
+	assert.equal(settings.getConfig().cursorStyle, "bar");
+	assert.match(selectedLine(settings.component), /Cursor style/);
+});
+
 test("keeps the changed setting selected", async () => {
 	const settings = await openSettings();
 
@@ -203,8 +214,9 @@ test("falls back to English for an invalid settings language", () => {
 	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
 	try {
 		process.env.PI_CODING_AGENT_DIR = agentDir;
-		writeFileSync(join(agentDir, "open-tui.json"), JSON.stringify({ settingsLanguage: "de" }), "utf8");
+		writeFileSync(join(agentDir, "open-tui.json"), JSON.stringify({ settingsLanguage: "de", cursorStyle: "invalid" }), "utf8");
 		assert.equal(loadConfig().settingsLanguage, "en");
+		assert.equal(loadConfig().cursorStyle, "block");
 	} finally {
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;

--- a/tests/settings-command.test.ts
+++ b/tests/settings-command.test.ts
@@ -6,6 +6,7 @@ import test from "node:test";
 import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
 import { visibleWidth, type Component, type KeybindingsManager, type TUI } from "@earendil-works/pi-tui";
 import { DEFAULT_CONFIG, loadConfig, type OpenTuiConfig } from "../extensions/open-tui/config.ts";
+import { installEditor } from "../extensions/open-tui/editor.ts";
 import { getPendingUiChange } from "../extensions/open-tui/index.ts";
 import { registerSettingsCommand } from "../extensions/open-tui/settings-command.ts";
 
@@ -19,7 +20,10 @@ const theme = {
 	bold: (text: string) => text,
 } as Theme;
 
-async function openSettings(initialConfig = structuredClone(DEFAULT_CONFIG)): Promise<{
+async function openSettings(
+	initialConfig = structuredClone(DEFAULT_CONFIG),
+	onChange?: (config: OpenTuiConfig) => void,
+): Promise<{
 	component: SettingsComponent;
 	getConfig: () => OpenTuiConfig;
 	isClosed: () => boolean;
@@ -42,6 +46,7 @@ async function openSettings(initialConfig = structuredClone(DEFAULT_CONFIG)): Pr
 		getConfig: () => config,
 		onConfigChanged: (nextConfig) => {
 			config = nextConfig;
+			onChange?.(nextConfig);
 		},
 		onOverlayClosed: () => {
 			overlayClosed = true;
@@ -105,23 +110,66 @@ test("closes cleanly after enabling or disabling the UI", async () => {
 	}
 });
 
-test("cycles cursor style from the Appearance tab", async () => {
-	const settings = await openSettings();
+test("previews cursor styles from the Appearance tab", async () => {
+	const writes: string[] = [];
+	let editorInstalls = 0;
+	let hardwareCursor = false;
+	const editorTui = {
+		terminal: { rows: 24, write: (data: string) => writes.push(data) },
+		requestRender() {},
+		getShowHardwareCursor: () => hardwareCursor,
+		setShowHardwareCursor: (enabled: boolean) => {
+			hardwareCursor = enabled;
+		},
+	} as unknown as TUI;
+	const editor = installEditor({} as ExtensionAPI, {
+		ui: {
+			setEditorComponent: (factory: unknown) => {
+				editorInstalls++;
+				if (typeof factory === "function") {
+					factory(editorTui, {
+						borderColor: (text: string) => text,
+						selectList: {},
+					}, { matches: () => false });
+				}
+			},
+		},
+	} as unknown as ExtensionContext);
+	const settings = await openSettings(undefined, (config) => editor.setCursorStyle(config.cursorStyle));
 
 	settings.component.handleInput("\t");
 	settings.component.handleInput("\x1b[B");
 	settings.component.handleInput("\r");
 
 	assert.equal(settings.getConfig().cursorStyle, "bar");
+	assert.equal(settings.isClosed(), false);
+	assert.equal(editorInstalls, 1);
+	assert.equal(hardwareCursor, true);
+	assert.ok(writes.includes("\x1b[6 q"));
+
+	settings.component.handleInput("\r");
+	assert.equal(settings.getConfig().cursorStyle, "underline");
+	assert.ok(writes.includes("\x1b[4 q"));
+
+	settings.component.handleInput("\r");
+	assert.equal(settings.getConfig().cursorStyle, "block");
+	assert.equal(hardwareCursor, false);
+	assert.ok(writes.includes("\x1b[0 q"));
+	assert.equal(editorInstalls, 1);
 	assert.match(selectedLine(settings.component), /Cursor style/);
 	assert.match(settings.component.render(80).join("\n"), /\[Appearance\].*Icon mode.*Cursor style/s);
+
+	settings.component.handleInput("q");
+	await settings.waitForClose();
+	assert.equal(settings.isOverlayClosed(), true);
+	editor.cleanup();
 });
 
-test("reconciles enabled and cursor style changes from the final config", () => {
-	assert.equal(getPendingUiChange(true, false, "block", true, "block"), "uninstall");
-	assert.equal(getPendingUiChange(false, false, "bar", true, "block"), undefined);
-	assert.equal(getPendingUiChange(false, true, "bar", true, "block"), "reinstall");
-	assert.equal(getPendingUiChange(false, true, "bar", false, undefined), "install");
+test("reconciles enabled changes with the installed UI", () => {
+	assert.equal(getPendingUiChange(true, false), "install");
+	assert.equal(getPendingUiChange(false, true), "uninstall");
+	assert.equal(getPendingUiChange(true, true), undefined);
+	assert.equal(getPendingUiChange(false, false), undefined);
 });
 
 test("keeps the changed setting selected", async () => {

--- a/tests/settings-command.test.ts
+++ b/tests/settings-command.test.ts
@@ -6,6 +6,7 @@ import test from "node:test";
 import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
 import { visibleWidth, type Component, type KeybindingsManager, type TUI } from "@earendil-works/pi-tui";
 import { DEFAULT_CONFIG, loadConfig, type OpenTuiConfig } from "../extensions/open-tui/config.ts";
+import { getPendingUiChange } from "../extensions/open-tui/index.ts";
 import { registerSettingsCommand } from "../extensions/open-tui/settings-command.ts";
 
 interface SettingsComponent extends Component {
@@ -104,15 +105,23 @@ test("closes cleanly after enabling or disabling the UI", async () => {
 	}
 });
 
-test("cycles cursor style from the General tab", async () => {
+test("cycles cursor style from the Appearance tab", async () => {
 	const settings = await openSettings();
 
-	settings.component.handleInput("\x1b[B");
+	settings.component.handleInput("\t");
 	settings.component.handleInput("\x1b[B");
 	settings.component.handleInput("\r");
 
 	assert.equal(settings.getConfig().cursorStyle, "bar");
 	assert.match(selectedLine(settings.component), /Cursor style/);
+	assert.match(settings.component.render(80).join("\n"), /\[Appearance\].*Icon mode.*Cursor style/s);
+});
+
+test("reconciles enabled and cursor style changes from the final config", () => {
+	assert.equal(getPendingUiChange(true, false, "block", true, "block"), "uninstall");
+	assert.equal(getPendingUiChange(false, false, "bar", true, "block"), undefined);
+	assert.equal(getPendingUiChange(false, true, "bar", true, "block"), "reinstall");
+	assert.equal(getPendingUiChange(false, true, "bar", false, undefined), "install");
 });
 
 test("keeps the changed setting selected", async () => {
@@ -174,7 +183,7 @@ test("supports localized settings and keyboard shortcuts", async () => {
 
 	reopened.component.handleInput("\x1b[B");
 	reopened.component.handleInput("\x1b[C");
-	assert.match(reopened.component.render(80).join("\n"), /\[图标\]/);
+	assert.match(reopened.component.render(80).join("\n"), /\[外观\].*图标模式.*光标样式/s);
 	reopened.component.handleInput("\x1b[D");
 	assert.match(selectedLine(reopened.component), /语言/);
 	reopened.component.handleInput("q");


### PR DESCRIPTION
## Summary

Adds configurable cursor styles for the rounded editor:

- `block` (default, preserves current behavior)
- `bar`
- `underline`

The setting is available as `cursorStyle` in `~/.pi/agent/open-tui.json` and through the `/open-tui` General settings tab, with English and Chinese labels.

For `bar` and `underline`, the extension uses Pi's public hardware-cursor API and standard terminal cursor-shape escape sequences, while removing the built-in reverse-video software cursor. Cursor markers and layout width are preserved, including narrow terminals.

Invalid config values fall back to `block`.

## Validation

- `npm test` (36 passing)
- `npm run typecheck`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增光标样式设置，支持块状、竖线和下划线三种样式。
  * “图标”设置页更名为“外观”，可循环切换光标样式并即时应用。
  * 非块状样式支持终端硬件光标显示。

* **文档**
  * 更新配置示例及光标样式选项说明，包括终端支持要求。

* **问题修复**
  * 无效的光标样式配置会自动回退为默认的块状样式。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->