### PR TITLE
feat: configurable fullscreen mouse wheel speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A polished terminal interface for the [Pi](https://pi.dev) coding agent. It brin
 - **Project awareness** for 50+ runtimes and detailed Git states, including ahead/behind, staged, modified, untracked, stashed, and detached HEAD
 - **Turn telemetry** for TPS, time to first token (TTFT), duration, stalls, tokens, and list-price rate
 - **Interactive settings** through `/open-tui`, available in English and Simplified Chinese
-- **Public Pi APIs only**: no prototype patching
+- **Version-guarded Pi compatibility shim**: fullscreen wheel speed falls back to Pi's default if its runtime support changes
 
 ## Requirements
 
@@ -57,6 +57,9 @@ Run `/open-tui` to open the settings dialog. It provides **General**, **Appearan
   "enabled": true,
   "settingsLanguage": "en",
   "cursorStyle": "block",
+  "fullscreen": {
+    "wheelScrollLines": 4
+  },
   "icons": {
     "mode": "auto"
   },
@@ -90,11 +93,14 @@ Key options:
 | --- | --- | --- |
 | `settingsLanguage` | `en`, `zh` | Changes the `/open-tui` interface language |
 | `cursorStyle` | `block`, `bar`, `underline` | `bar` and `underline` require terminal cursor-shape support |
+| `fullscreen.wheelScrollLines` | `1`-`10` | Lines scrolled per mouse-wheel notch in fullscreen mode; defaults to `4`. `/open-tui` cycles through `1`, `4`, `7`, and `10` for quick switching |
 | `icons.mode` | `auto`, `nerd`, `ascii` | Controls footer and telemetry icons |
 | `footerSegments` | Boolean flags | Shows or hides individual footer data |
 | `telemetry` | Boolean flags | Enables telemetry and its individual measurements |
 
 `sessionName` appears only when the session has a name. `gitCommit` shows the short hash and tag in detached HEAD state. Disabling `extensionStatuses` hides the entire extension status line, including MCP status.
+
+Fullscreen wheel speed uses an isolated compatibility shim for Pi 0.84.2's runtime field because Pi does not yet expose a public setter. On Pi versions without a compatible field, the setting is ignored and Pi's default scrolling remains active.
 
 ## Turn telemetry
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@
 - **项目环境感知**：识别 50 多种运行环境，并展示 ahead/behind、已暂存、已修改、未跟踪、stash 和 detached HEAD 等 Git 状态
 - **单轮遥测**：展示 TPS、首 Token 延迟（TTFT）、耗时、停顿、Token 数量和模型标价速率
 - **交互式设置**：通过 `/open-tui` 配置，并支持英文和简体中文界面
-- **仅使用 Pi 公共 API**：不修改原型，降低 Pi 升级带来的兼容风险
+- **带版本保护的 Pi 兼容层**：全屏滚轮速度所依赖的运行时支持发生变化时，会回退为 Pi 默认行为
 
 ## 环境要求
 
@@ -57,6 +57,9 @@ pi -e npm:pi-open-tui
   "enabled": true,
   "settingsLanguage": "zh",
   "cursorStyle": "block",
+  "fullscreen": {
+    "wheelScrollLines": 4
+  },
   "icons": {
     "mode": "auto"
   },
@@ -90,11 +93,14 @@ pi -e npm:pi-open-tui
 | --- | --- | --- |
 | `settingsLanguage` | `en`、`zh` | 切换 `/open-tui` 设置界面的语言 |
 | `cursorStyle` | `block`、`bar`、`underline` | `bar` 和 `underline` 需要终端支持光标形状转义序列 |
+| `fullscreen.wheelScrollLines` | `1`-`10` | 全屏模式下滚轮每格滚动的行数，默认值为 `4`；`/open-tui` 使用 `1`、`4`、`7`、`10` 四档快速切换 |
 | `icons.mode` | `auto`、`nerd`、`ascii` | 控制底栏和遥测通知使用的图标 |
 | `footerSegments` | 布尔开关 | 分别控制底栏中的各项数据 |
 | `telemetry` | 布尔开关 | 控制遥测总开关和各项指标 |
 
 `sessionName` 仅在会话有名称时显示；`gitCommit` 会在 detached HEAD 状态下显示短哈希和标签；关闭 `extensionStatuses` 会隐藏整行扩展状态，其中也包括 MCP 状态。
+
+全屏滚轮速度通过隔离的兼容层写入 Pi 0.84.2 的运行时字段，因为 Pi 尚未提供公开 setter。若后续 Pi 版本不再包含兼容字段，该设置会被忽略并继续使用 Pi 的默认滚动行为。
 
 ## 单轮遥测
 

--- a/extensions/open-tui/config.ts
+++ b/extensions/open-tui/config.ts
@@ -1,6 +1,10 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import {
+	DEFAULT_FULLSCREEN_WHEEL_SCROLL_LINES,
+	normalizeFullscreenWheelScrollLines,
+} from "./fullscreen-scroll.ts";
 import type { IconMode } from "./icons.ts";
 
 export type SettingsLanguage = "en" | "zh";
@@ -31,10 +35,15 @@ export interface TelemetryConfig {
 	cost: boolean;
 }
 
+export interface FullscreenConfig {
+	wheelScrollLines: number;
+}
+
 export interface OpenTuiConfig {
 	enabled: boolean;
 	settingsLanguage: SettingsLanguage;
 	cursorStyle: CursorStyle;
+	fullscreen: FullscreenConfig;
 	icons: {
 		mode: IconMode;
 	};
@@ -46,6 +55,9 @@ export const DEFAULT_CONFIG: OpenTuiConfig = {
 	enabled: true,
 	settingsLanguage: "en",
 	cursorStyle: "block",
+	fullscreen: {
+		wheelScrollLines: DEFAULT_FULLSCREEN_WHEEL_SCROLL_LINES,
+	},
 	icons: {
 		mode: "auto",
 	},
@@ -128,6 +140,10 @@ export function loadConfig(notify?: (msg: string, level: "warning" | "info") => 
 		if (config.cursorStyle !== "block" && config.cursorStyle !== "bar" && config.cursorStyle !== "underline") {
 			config.cursorStyle = DEFAULT_CONFIG.cursorStyle;
 		}
+		config.fullscreen.wheelScrollLines = normalizeFullscreenWheelScrollLines(
+			config.fullscreen.wheelScrollLines,
+			DEFAULT_CONFIG.fullscreen.wheelScrollLines,
+		);
 		return config;
 	} catch (err) {
 		notify?.(`open-tui config parse error: ${err instanceof Error ? err.message : String(err)}`, "warning");

--- a/extensions/open-tui/editor.ts
+++ b/extensions/open-tui/editor.ts
@@ -7,6 +7,10 @@ import {
 import type { EditorTheme, TUI } from "@earendil-works/pi-tui";
 import { CURSOR_MARKER, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { CursorStyle } from "./config.ts";
+import {
+	applyFullscreenWheelScrollLines,
+	DEFAULT_FULLSCREEN_WHEEL_SCROLL_LINES,
+} from "./fullscreen-scroll.ts";
 import { findBottomBorderIndex, isEditorBorderLine, stripAnsi } from "./utils.ts";
 
 function fillLine(content: string, width: number): string {
@@ -151,14 +155,17 @@ export function installEditor(
 	_pi: ExtensionAPI,
 	ctx: ExtensionContext,
 	cursorStyle: CursorStyle = "block",
+	wheelScrollLines = DEFAULT_FULLSCREEN_WHEEL_SCROLL_LINES,
 ) {
 	let activeTui: TUI | undefined;
 	let activeEditor: OpenTuiEditor | undefined;
 	let previousHardwareCursor: boolean | undefined;
 	let currentCursorStyle = cursorStyle;
+	let currentWheelScrollLines = wheelScrollLines;
 
 	ctx.ui.setEditorComponent((tui, editorTheme, keybindings) => {
 		activeTui = tui;
+		applyFullscreenWheelScrollLines(tui, currentWheelScrollLines);
 		previousHardwareCursor = tui.getShowHardwareCursor();
 		activeEditor = new OpenTuiEditor(tui, editorTheme, keybindings, currentCursorStyle);
 		return activeEditor;
@@ -167,6 +174,10 @@ export function installEditor(
 		setCursorStyle(nextCursorStyle: CursorStyle): void {
 			currentCursorStyle = nextCursorStyle;
 			activeEditor?.setCursorStyle(nextCursorStyle, previousHardwareCursor);
+		},
+		setWheelScrollLines(nextWheelScrollLines: number): void {
+			currentWheelScrollLines = nextWheelScrollLines;
+			if (activeTui) applyFullscreenWheelScrollLines(activeTui, currentWheelScrollLines);
 		},
 		cleanup(): void {
 			ctx.ui.setEditorComponent(undefined);

--- a/extensions/open-tui/fullscreen-scroll.ts
+++ b/extensions/open-tui/fullscreen-scroll.ts
@@ -1,0 +1,34 @@
+import type { TUI } from "@earendil-works/pi-tui";
+
+export const MIN_FULLSCREEN_WHEEL_SCROLL_LINES = 1;
+export const MAX_FULLSCREEN_WHEEL_SCROLL_LINES = 10;
+export const DEFAULT_FULLSCREEN_WHEEL_SCROLL_LINES = 4;
+
+export function normalizeFullscreenWheelScrollLines(
+	value: unknown,
+	fallback = DEFAULT_FULLSCREEN_WHEEL_SCROLL_LINES,
+): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+	return Math.min(
+		MAX_FULLSCREEN_WHEEL_SCROLL_LINES,
+		Math.max(MIN_FULLSCREEN_WHEEL_SCROLL_LINES, Math.floor(value)),
+	);
+}
+
+type FullscreenWheelTui = TUI & { wheelScrollLines?: unknown };
+
+/**
+ * Pi 0.84.2 keeps this constructor option in a private runtime field. Remove
+ * this shim once Pi exposes a public setter; incompatible versions are no-ops.
+ */
+export function applyFullscreenWheelScrollLines(tui: TUI, value: number): boolean {
+	try {
+		const fullscreenTui = tui as FullscreenWheelTui;
+		if (fullscreenTui.mode !== "fullscreen" || typeof fullscreenTui.wheelScrollLines !== "number") {
+			return false;
+		}
+		return Reflect.set(fullscreenTui, "wheelScrollLines", normalizeFullscreenWheelScrollLines(value));
+	} catch {
+		return false;
+	}
+}

--- a/extensions/open-tui/index.ts
+++ b/extensions/open-tui/index.ts
@@ -87,7 +87,7 @@ export default function (pi: ExtensionAPI) {
 					},
 				},
 			);
-			editor = installEditor(pi, ctx, config.cursorStyle);
+			editor = installEditor(pi, ctx, config.cursorStyle, config.fullscreen.wheelScrollLines);
 			active = true;
 		}
 	};
@@ -273,10 +273,14 @@ export default function (pi: ExtensionAPI) {
 		getConfig: () => config,
 		onConfigChanged: (newConfig) => {
 			const cursorStyleChanged = config.cursorStyle !== newConfig.cursorStyle;
+			const wheelScrollLinesChanged = config.fullscreen.wheelScrollLines !== newConfig.fullscreen.wheelScrollLines;
 			saveConfig(newConfig);
 			config = newConfig;
 			if (cursorStyleChanged && active && editor) {
 				editor.setCursorStyle(newConfig.cursorStyle);
+			}
+			if (wheelScrollLinesChanged && active && editor) {
+				editor.setWheelScrollLines(newConfig.fullscreen.wheelScrollLines);
 			}
 			if (lastCtx) {
 				pendingUiChange = getPendingUiChange(newConfig.enabled, active);

--- a/extensions/open-tui/settings-command.ts
+++ b/extensions/open-tui/settings-command.ts
@@ -10,6 +10,8 @@ import {
 } from "@earendil-works/pi-tui";
 import type { CursorStyle, IconMode, OpenTuiConfig, SettingsLanguage } from "./config.ts";
 
+const WHEEL_SCROLL_PRESETS = [1, 4, 7, 10] as const;
+
 interface SettingItem {
 	id: string;
 	label: string;
@@ -28,6 +30,7 @@ const COPY = {
 		labels: {
 			enabled: "Enabled",
 			language: "Language",
+			wheelScrollLines: "Mouse wheel speed",
 			cursorStyle: "Cursor style",
 			iconMode: "Icon mode",
 			cwd: "CWD",
@@ -49,6 +52,7 @@ const COPY = {
 			on: "On",
 			off: "Off",
 			languages: { en: "English", zh: "简体中文" },
+			wheelLines: (count: number) => `${count} ${count === 1 ? "line" : "lines"} / notch`,
 			cursorStyles: { block: "Block", bar: "Bar", underline: "Underline" },
 			icons: { auto: "Auto", nerd: "Nerd", ascii: "ASCII" },
 		},
@@ -60,6 +64,7 @@ const COPY = {
 		labels: {
 			enabled: "启用",
 			language: "语言",
+			wheelScrollLines: "鼠标滚轮速度",
 			cursorStyle: "光标样式",
 			iconMode: "图标模式",
 			cwd: "当前目录",
@@ -81,6 +86,7 @@ const COPY = {
 			on: "开启",
 			off: "关闭",
 			languages: { en: "English", zh: "简体中文" },
+			wheelLines: (count: number) => `每格 ${count} 行`,
 			cursorStyles: { block: "块", bar: "竖线", underline: "下划线" },
 			icons: { auto: "自动", nerd: "Nerd", ascii: "ASCII" },
 		},
@@ -121,6 +127,12 @@ function cycleCursorStyle(config: OpenTuiConfig): OpenTuiConfig {
 	return { ...config, cursorStyle: next };
 }
 
+function cycleWheelScrollLines(config: OpenTuiConfig): OpenTuiConfig {
+	const current = config.fullscreen.wheelScrollLines;
+	const wheelScrollLines = WHEEL_SCROLL_PRESETS.find((value) => value > current) ?? WHEEL_SCROLL_PRESETS[0];
+	return { ...config, fullscreen: { ...config.fullscreen, wheelScrollLines } };
+}
+
 function toggleTelemetry(config: OpenTuiConfig, key: keyof OpenTuiConfig["telemetry"]): OpenTuiConfig {
 	return {
 		...config,
@@ -132,6 +144,11 @@ function buildFeaturesItems(config: OpenTuiConfig, copy: SettingsCopy): SettingI
 	return [
 		{ id: "enabled", label: copy.labels.enabled, currentValue: config.enabled ? copy.values.on : copy.values.off },
 		{ id: "settingsLanguage", label: copy.labels.language, currentValue: copy.values.languages[config.settingsLanguage] },
+		{
+			id: "wheelScrollLines",
+			label: copy.labels.wheelScrollLines,
+			currentValue: copy.values.wheelLines(config.fullscreen.wheelScrollLines),
+		},
 	];
 }
 
@@ -191,6 +208,7 @@ function handleSettingChange(
 	if (tab === "features") {
 		if (itemId === "enabled") return toggleEnabled(config);
 		if (itemId === "settingsLanguage") return toggleLanguage(config);
+		if (itemId === "wheelScrollLines") return cycleWheelScrollLines(config);
 	}
 	if (tab === "icons") {
 		if (itemId === "mode") return cycleIconMode(config);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "test": "node --test tests/settings-command.test.ts tests/footer.test.ts tests/editor.test.ts tests/telemetry.test.ts",
+    "test": "node --test tests/settings-command.test.ts tests/fullscreen-scroll.test.ts tests/footer.test.ts tests/editor.test.ts tests/telemetry.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "pi": {

--- a/tests/fullscreen-scroll.test.ts
+++ b/tests/fullscreen-scroll.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import {
+	TuiAltScreen,
+	type EditorTheme,
+	type KeybindingsManager,
+	type Terminal,
+	type TUI,
+} from "@earendil-works/pi-tui";
+import { DEFAULT_CONFIG, loadConfig } from "../extensions/open-tui/config.ts";
+import { installEditor } from "../extensions/open-tui/editor.ts";
+import {
+	applyFullscreenWheelScrollLines,
+	DEFAULT_FULLSCREEN_WHEEL_SCROLL_LINES,
+	MAX_FULLSCREEN_WHEEL_SCROLL_LINES,
+	MIN_FULLSCREEN_WHEEL_SCROLL_LINES,
+	normalizeFullscreenWheelScrollLines,
+} from "../extensions/open-tui/fullscreen-scroll.ts";
+
+const editorTheme = {
+	borderColor: (text: string) => text,
+	selectList: {},
+} as EditorTheme;
+
+test("defaults and normalizes fullscreen mouse wheel speed", () => {
+	assert.equal(DEFAULT_FULLSCREEN_WHEEL_SCROLL_LINES, 4);
+	assert.equal(DEFAULT_CONFIG.fullscreen.wheelScrollLines, 4);
+	assert.equal(normalizeFullscreenWheelScrollLines(0), MIN_FULLSCREEN_WHEEL_SCROLL_LINES);
+	assert.equal(normalizeFullscreenWheelScrollLines(3.9), 3);
+	assert.equal(normalizeFullscreenWheelScrollLines(100), MAX_FULLSCREEN_WHEEL_SCROLL_LINES);
+	assert.equal(normalizeFullscreenWheelScrollLines("fast"), DEFAULT_FULLSCREEN_WHEEL_SCROLL_LINES);
+	assert.equal(normalizeFullscreenWheelScrollLines(Number.NaN), DEFAULT_FULLSCREEN_WHEEL_SCROLL_LINES);
+});
+
+test("loads old configs and normalizes persisted fullscreen values", () => {
+	const agentDir = mkdtempSync(join(tmpdir(), "pi-open-tui-fullscreen-"));
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	try {
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		const configPath = join(agentDir, "open-tui.json");
+		writeFileSync(configPath, JSON.stringify({ enabled: false }), "utf8");
+		assert.equal(loadConfig().fullscreen.wheelScrollLines, 4);
+
+		writeFileSync(configPath, JSON.stringify({ fullscreen: { wheelScrollLines: 12.8 } }), "utf8");
+		assert.equal(loadConfig().fullscreen.wheelScrollLines, 10);
+
+		writeFileSync(configPath, JSON.stringify({ fullscreen: { wheelScrollLines: "fast" } }), "utf8");
+		assert.equal(loadConfig().fullscreen.wheelScrollLines, 4);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		rmSync(agentDir, { recursive: true, force: true });
+	}
+});
+
+test("applies speed only to compatible fullscreen TUI instances", () => {
+	const fullscreen = new TuiAltScreen({} as unknown as Terminal);
+	assert.equal(applyFullscreenWheelScrollLines(fullscreen, 6), true);
+	assert.equal((fullscreen as unknown as { wheelScrollLines: number }).wheelScrollLines, 6);
+
+	const regular = { mode: "regular", wheelScrollLines: 1 } as unknown as TUI;
+	assert.equal(applyFullscreenWheelScrollLines(regular, 6), false);
+	assert.equal((regular as unknown as { wheelScrollLines: number }).wheelScrollLines, 1);
+
+	const missingField = { mode: "fullscreen" } as unknown as TUI;
+	assert.equal(applyFullscreenWheelScrollLines(missingField, 6), false);
+	assert.equal("wheelScrollLines" in missingField, false);
+});
+
+test("silently ignores a fullscreen speed field that becomes read-only", () => {
+	const tui = { mode: "fullscreen" };
+	Object.defineProperty(tui, "wheelScrollLines", { value: 1, writable: false });
+
+	assert.doesNotThrow(() => applyFullscreenWheelScrollLines(tui as unknown as TUI, 6));
+	assert.equal(applyFullscreenWheelScrollLines(tui as unknown as TUI, 6), false);
+	assert.equal((tui as unknown as { wheelScrollLines: number }).wheelScrollLines, 1);
+});
+
+test("applies fullscreen speed on editor mount and updates it without reinstalling", () => {
+	let editorInstalls = 0;
+	let hardwareCursor = false;
+	const tui = {
+		mode: "fullscreen",
+		wheelScrollLines: 1,
+		terminal: { rows: 24, write() {} },
+		requestRender() {},
+		getShowHardwareCursor: () => hardwareCursor,
+		setShowHardwareCursor: (enabled: boolean) => {
+			hardwareCursor = enabled;
+		},
+	} as unknown as TUI;
+	const ctx = {
+		ui: {
+			setEditorComponent: (factory: unknown) => {
+				if (typeof factory !== "function") return;
+				editorInstalls++;
+				factory(tui, editorTheme, { matches: () => false } as unknown as KeybindingsManager);
+			},
+		},
+	} as unknown as ExtensionContext;
+
+	const editor = installEditor({} as ExtensionAPI, ctx, "block", 6);
+	assert.equal((tui as unknown as { wheelScrollLines: number }).wheelScrollLines, 6);
+
+	editor.setWheelScrollLines(9);
+	assert.equal((tui as unknown as { wheelScrollLines: number }).wheelScrollLines, 9);
+	assert.equal(editorInstalls, 1);
+	editor.cleanup();
+});

--- a/tests/settings-command.test.ts
+++ b/tests/settings-command.test.ts
@@ -110,6 +110,27 @@ test("closes cleanly after enabling or disabling the UI", async () => {
 	}
 });
 
+test("updates fullscreen mouse wheel speed while settings stay open", async () => {
+	const applied: number[] = [];
+	const settings = await openSettings(undefined, (config) => {
+		applied.push(config.fullscreen.wheelScrollLines);
+	});
+
+	settings.component.handleInput("\x1b[B");
+	settings.component.handleInput("\x1b[B");
+	assert.match(selectedLine(settings.component), /Mouse wheel speed/);
+
+	settings.component.handleInput(" ");
+	assert.equal(settings.getConfig().fullscreen.wheelScrollLines, 7);
+	assert.deepEqual(applied, [7]);
+	assert.equal(settings.isClosed(), false);
+	assert.match(selectedLine(settings.component), /Mouse wheel speed/);
+
+	settings.component.handleInput("\r");
+	settings.component.handleInput("\r");
+	assert.equal(settings.getConfig().fullscreen.wheelScrollLines, 1);
+});
+
 test("previews cursor styles from the Appearance tab", async () => {
 	const writes: string[] = [];
 	let editorInstalls = 0;


### PR DESCRIPTION
## Summary

- add `fullscreen.wheelScrollLines` to `open-tui.json`, defaulting to `4` and normalized to `1..10`
- expose `1`, `4`, `7`, and `10` mouse wheel speed presets in `/open-tui` and apply changes immediately without reinstalling the editor
- isolate the Pi fullscreen runtime compatibility access so unsupported or read-only fields fall back to Pi default behavior
- document the setting and compatibility boundary in English and Simplified Chinese

## Compatibility

Pi 0.84.2 exposes `wheelScrollLines` as a `TuiAltScreen` constructor option, but coding-agent does not currently expose a public runtime setter to extensions. The compatibility shim only writes when `TUI.mode === "fullscreen"` and the numeric runtime property exists. Missing, renamed, or read-only properties are silent no-ops.

Related upstream issue: https://github.com/earendil-works/pi/issues/7765

## Verification

- `npm run typecheck`
- `npm test` (`46/46` tests, exit code `0`)
- real `TuiAltScreen@0.84.2` runtime probe: injected wheel events moved `1` line before the update and `4` lines after it

## Rollback

The feature is isolated in one commit and the branch is retained. Revert it with:

```bash
git revert 1445ae9123c51ae1b6ee7f1fd0d13048f10bc25c
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增全屏模式鼠标滚轮速度设置，可配置每格滚动 1–10 行，默认值为 4。
  - 支持在设置界面按 1、4、7、10 四档循环调整滚轮速度，并实时应用到当前界面。
  - 兼容支持相关运行时版本；不兼容时自动使用默认滚动行为。

- **文档**
  - 更新中英文配置说明、兼容性说明及示例。

- **测试**
  - 新增全屏滚动配置、动态更新及设置界面操作的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->