### PR TITLE
fix: enhance underline cursor visibility

### DIFF
--- a/extensions/open-tui/editor.ts
+++ b/extensions/open-tui/editor.ts
@@ -25,9 +25,10 @@ const CURSOR_STYLE_SEQUENCES: Partial<Record<CursorStyle, string>> = {
 };
 const DEFAULT_CURSOR_STYLE_SEQUENCE = "\x1b[0 q";
 
-function removeSoftwareCursor(line: string, cursorMarker = ""): string {
+function removeSoftwareCursor(line: string, cursorMarker = "", cursorStyle: CursorStyle = "block"): string {
 	return line.replace(/\x1b\[7m([\s\S]*?)\x1b\[0m/g, (_match, cursor: string) => {
-		const replacement = `${cursorMarker}${cursor}`;
+		const formattedCursor = cursorStyle === "underline" ? `\x1b[4m${cursor}\x1b[0m` : cursor;
+		const replacement = `${cursorMarker}${formattedCursor}`;
 		cursorMarker = "";
 		return replacement;
 	});
@@ -113,7 +114,7 @@ export class OpenTuiEditor extends CustomEditor {
 		let cursorMarker = this.previewHardwareCursor && !this.focused ? CURSOR_MARKER : "";
 		if (this.focused) this.previewHardwareCursor = false;
 		return renderedLines.map((line) => {
-			const rendered = removeSoftwareCursor(line, cursorMarker);
+			const rendered = removeSoftwareCursor(line, cursorMarker, this.cursorStyle);
 			if (rendered !== line) cursorMarker = "";
 			return rendered;
 		});

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -65,6 +65,9 @@ test("uses the terminal hardware cursor for non-block styles", () => {
 		assert.equal(hardwareCursor, true);
 		assert.ok(writes.includes(sequence), `${cursorStyle} cursor sequence was sent`);
 		assert.ok(lines.every((line) => !line.includes("\x1b[7m")), "software block cursor was removed");
+		if (cursorStyle === "underline") {
+			assert.ok(lines.some((line) => line.includes("\x1b[4m")), "underline styling was applied to the cursor character");
+		}
 	}
 });
 


### PR DESCRIPTION
## Summary

Enhances software-level cursor visibility for `underline` cursor style:

- When `cursorStyle === "underline"`, instead of purely stripping the software reverse-video sequence (`\x1b[7m`), the editor wraps the character at the cursor with ANSI underline (`\x1b[4m${cursor}\x1b[0m`).
- Provides software-level visibility for the underline cursor regardless of whether the terminal syncs hardware cursor positions in full-screen TUI mode, while preserving the zero-width `CURSOR_MARKER` for IME positioning.
- Added test coverage in `tests/editor.test.ts` for underline ANSI styling.

## Validation

- `npm test` (46 passing tests)
- `npm run typecheck`