### PR TITLE
feat: expand fullscreen wheel speed presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Key options:
 | --- | --- | --- |
 | `settingsLanguage` | `en`, `zh` | Changes the `/open-tui` interface language |
 | `cursorStyle` | `block`, `bar`, `underline` | `bar` and `underline` require terminal cursor-shape support |
-| `fullscreen.wheelScrollLines` | `1`-`10` | Lines scrolled per mouse-wheel notch in fullscreen mode; defaults to `4`. `/open-tui` cycles through `1`, `4`, `7`, and `10` for quick switching |
+| `fullscreen.wheelScrollLines` | `1`-`10` | Lines scrolled per mouse-wheel notch in fullscreen mode; defaults to `4`. `/open-tui` cycles through `1`, `2`, `3`, `4`, `7`, and `10` for quick switching |
 | `icons.mode` | `auto`, `nerd`, `ascii` | Controls footer and telemetry icons |
 | `footerSegments` | Boolean flags | Shows or hides individual footer data |
 | `telemetry` | Boolean flags | Enables telemetry and its individual measurements |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -93,7 +93,7 @@ pi -e npm:pi-open-tui
 | --- | --- | --- |
 | `settingsLanguage` | `en`、`zh` | 切换 `/open-tui` 设置界面的语言 |
 | `cursorStyle` | `block`、`bar`、`underline` | `bar` 和 `underline` 需要终端支持光标形状转义序列 |
-| `fullscreen.wheelScrollLines` | `1`-`10` | 全屏模式下滚轮每格滚动的行数，默认值为 `4`；`/open-tui` 使用 `1`、`4`、`7`、`10` 四档快速切换 |
+| `fullscreen.wheelScrollLines` | `1`-`10` | 全屏模式下滚轮每格滚动的行数，默认值为 `4`；`/open-tui` 使用 `1`、`2`、`3`、`4`、`7`、`10` 快速切换 |
 | `icons.mode` | `auto`、`nerd`、`ascii` | 控制底栏和遥测通知使用的图标 |
 | `footerSegments` | 布尔开关 | 分别控制底栏中的各项数据 |
 | `telemetry` | 布尔开关 | 控制遥测总开关和各项指标 |

--- a/extensions/open-tui/settings-command.ts
+++ b/extensions/open-tui/settings-command.ts
@@ -10,7 +10,7 @@ import {
 } from "@earendil-works/pi-tui";
 import type { CursorStyle, IconMode, OpenTuiConfig, SettingsLanguage } from "./config.ts";
 
-const WHEEL_SCROLL_PRESETS = [1, 4, 7, 10] as const;
+const WHEEL_SCROLL_PRESETS = [1, 2, 3, 4, 7, 10] as const;
 
 interface SettingItem {
 	id: string;

--- a/tests/settings-command.test.ts
+++ b/tests/settings-command.test.ts
@@ -127,8 +127,13 @@ test("updates fullscreen mouse wheel speed while settings stay open", async () =
 	assert.match(selectedLine(settings.component), /Mouse wheel speed/);
 
 	settings.component.handleInput("\r");
+	assert.equal(settings.getConfig().fullscreen.wheelScrollLines, 10);
 	settings.component.handleInput("\r");
 	assert.equal(settings.getConfig().fullscreen.wheelScrollLines, 1);
+	settings.component.handleInput("\r");
+	assert.equal(settings.getConfig().fullscreen.wheelScrollLines, 2);
+	settings.component.handleInput("\r");
+	assert.equal(settings.getConfig().fullscreen.wheelScrollLines, 3);
 });
 
 test("previews cursor styles from the Appearance tab", async () => {


### PR DESCRIPTION
## Summary

Expands the `/open-tui` settings overlay wheel speed cycle presets from `[1, 4, 7, 10]` to `[1, 2, 3, 4, 7, 10]`:

- Allows users to directly cycle through finer mouse wheel scroll steps (such as 2 or 3 lines per notch) within the interactive settings UI.
- Updated unit test assertions in `tests/settings-command.test.ts` to cover the expanded cycle sequence.
- Updated documentation in both English and Simplified Chinese README files.

## Validation

- `npm test` (46 passing tests)
- `npm run typecheck`
- `tests/settings-command.test.ts` verified cycling across `10 -> 1 -> 2 -> 3`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 扩展全屏模式下的滚轮滚动速度选项，现可在 `1、2、3、4、7、10` 六档之间循环切换。
  * 默认滚动速度及配置取值范围保持不变。

* **文档**
  * 更新中英文配置说明，反映新增的滚轮速度选项。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->