### PR TITLE
fix: tolerate invalid assistant usage

### DIFF
--- a/extensions/open-tui/state.ts
+++ b/extensions/open-tui/state.ts
@@ -3,7 +3,7 @@ import type { AssistantMessage } from "@earendil-works/pi-ai";
 import type { GitStatus } from "./git.ts";
 import { emptyGitStatus } from "./git.ts";
 import type { RuntimeInfo } from "./runtime.ts";
-import { fmtTokens, formatProviderLabel } from "./utils.ts";
+import { finiteOrZero, fmtTokens, formatProviderLabel } from "./utils.ts";
 
 export interface FooterState {
 	git: GitStatus;
@@ -43,14 +43,17 @@ export function getUsageTotals(ctx: ExtensionContext): UsageTotals {
 			const m = entry.message as AssistantMessage;
 			const u = m.usage;
 			if (!u) continue;
-			totals.input += u.input ?? 0;
-			totals.output += u.output ?? 0;
-			totals.cacheRead += u.cacheRead ?? 0;
-			totals.cacheWrite += u.cacheWrite ?? 0;
-			totals.cost += u.cost?.total ?? 0;
-			const promptTokens = (u.input ?? 0) + (u.cacheRead ?? 0) + (u.cacheWrite ?? 0);
+			const input = finiteOrZero(u.input);
+			const cacheRead = finiteOrZero(u.cacheRead);
+			const cacheWrite = finiteOrZero(u.cacheWrite);
+			totals.input += input;
+			totals.output += finiteOrZero(u.output);
+			totals.cacheRead += cacheRead;
+			totals.cacheWrite += cacheWrite;
+			totals.cost += finiteOrZero(u.cost?.total);
+			const promptTokens = input + cacheRead + cacheWrite;
 			if (promptTokens > 0) {
-				totals.latestCacheHitRate = ((u.cacheRead ?? 0) / promptTokens) * 100;
+				totals.latestCacheHitRate = (cacheRead / promptTokens) * 100;
 			}
 		}
 	}

--- a/extensions/open-tui/telemetry.ts
+++ b/extensions/open-tui/telemetry.ts
@@ -11,7 +11,7 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import type { IconMode, TelemetryConfig } from "./config.ts";
 import { resolveGlyphs } from "./icons.ts";
-import { fmtTokens, formatDuration } from "./utils.ts";
+import { finiteOrZero, fmtTokens, formatDuration } from "./utils.ts";
 
 const STALL_THRESHOLD_MS = 1000;
 
@@ -168,7 +168,7 @@ export class TurnTelemetryTracker {
 		if (current) {
 			const endMs = this.now();
 			turn.generationMs = endMs - turn.startMs;
-			if (current.firstOutputMs === null && message.usage.output > 0) {
+			if (current.firstOutputMs === null && finiteOrZero(message.usage?.output) > 0) {
 				turn.firstTokenMs ??= endMs;
 			}
 			turn.currentMessage = null;
@@ -193,13 +193,10 @@ export class TurnTelemetryTracker {
 		let totalTokens = 0;
 		let costUsd = 0;
 		for (const message of turn.messages) {
-			inputTokens += message.usage.input;
-			outputTokens += message.usage.output;
-			totalTokens += message.usage.totalTokens;
-			costUsd += message.usage.cost.total;
-		}
-		if (![inputTokens, outputTokens, totalTokens, costUsd].every(Number.isFinite)) {
-			throw new Error("Invalid assistant usage in turn telemetry");
+			inputTokens += finiteOrZero(message.usage?.input);
+			outputTokens += finiteOrZero(message.usage?.output);
+			totalTokens += finiteOrZero(message.usage?.totalTokens);
+			costUsd += finiteOrZero(message.usage?.cost?.total);
 		}
 
 		const measurementMs = outputTokens > 0 && turn.generationMs > 0 ? turn.generationMs : null;

--- a/extensions/open-tui/utils.ts
+++ b/extensions/open-tui/utils.ts
@@ -55,6 +55,10 @@ export function truncatePath(path: string, maxLen: number): string {
 	return result.length > maxLen ? result.slice(0, maxLen - 3) + "..." : result;
 }
 
+export function finiteOrZero(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
 export function fmtTokens(n: number): string {
 	if (n < 1000) return n.toString();
 	if (n < 10_000) return `${(n / 1000).toFixed(1)}k`;

--- a/tests/footer.test.ts
+++ b/tests/footer.test.ts
@@ -10,7 +10,7 @@ import { DEFAULT_CONFIG } from "../extensions/open-tui/config.ts";
 import { installFooter } from "../extensions/open-tui/footer.ts";
 import { emptyGitStatus } from "../extensions/open-tui/git.ts";
 import { resolveGlyphs } from "../extensions/open-tui/icons.ts";
-import type { FooterState } from "../extensions/open-tui/state.ts";
+import { getUsageTotals, invalidateUsageCache, type FooterState } from "../extensions/open-tui/state.ts";
 import { fitSegmentsByPriority, truncateBranch, truncatePath } from "../extensions/open-tui/utils.ts";
 
 const theme = {
@@ -173,6 +173,27 @@ test("both icon modes provide every footer semantic", () => {
 		const glyphs = resolveGlyphs(mode);
 		for (const key of keys) assert.notEqual(glyphs[key], "", `${mode}.${key}`);
 	}
+});
+
+test("normalizes invalid usage totals", () => {
+	const usage = {
+		input: Number.POSITIVE_INFINITY,
+		output: undefined,
+		cacheRead: 100,
+		cacheWrite: null,
+		cost: { total: Number.NaN },
+	};
+	const ctx = {
+		sessionManager: {
+			getEntries: () => [{ id: "invalid-usage", timestamp: 1, type: "message", message: { role: "assistant", usage } }],
+		},
+	} as unknown as ExtensionContext;
+
+	invalidateUsageCache();
+	assert.deepEqual(getUsageTotals(ctx), {
+		input: 0, output: 0, cacheRead: 100, cacheWrite: 0, cost: 0, latestCacheHitRate: 100,
+	});
+	invalidateUsageCache();
 });
 
 test("ASCII footer renders icons as semantic labels", () => {

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -94,6 +94,30 @@ test("uses total output over full generation time", () => {
 	);
 });
 
+test("normalizes invalid usage without breaking turn telemetry", () => {
+	let now = 0;
+	const tracker = new TurnTelemetryTracker(() => now);
+	const messages = [makeMessage(), makeMessage()];
+	Object.assign(messages[0]!.usage, { input: Number.POSITIVE_INFINITY, totalTokens: null, cost: { total: Number.NaN } });
+	Object.assign(messages[1]!.usage, { output: undefined, cost: undefined });
+
+	tracker.handle({ type: "turn_start", turnIndex: 0, timestamp: Date.now() });
+	for (const message of messages) {
+		tracker.handle({ type: "message_start", message });
+		now += 100;
+		tracker.handle(update(message));
+		now += 100;
+		tracker.handle({ type: "message_end", message });
+	}
+	const telemetry = tracker.handle({ type: "turn_end", turnIndex: 0, message: messages[1]!, toolResults: [] })!;
+
+	assert.equal(telemetry.inputTokens, 50);
+	assert.equal(telemetry.outputTokens, 20);
+	assert.equal(telemetry.totalTokens, 70);
+	assert.equal(telemetry.costUsd, 0);
+	assert.equal(telemetry.rateUsdPerMTokens, null);
+});
+
 test("measures non-streamed responses from turn start", () => {
 	let now = 0;
 	const tracker = new TurnTelemetryTracker(() => now);


### PR DESCRIPTION
## Summary
- Normalize missing and non-finite assistant usage values before telemetry and footer aggregation.
- Reuse one finite-number boundary for turn telemetry, non-streamed output detection, and session usage totals.
- Add regression coverage for invalid token, cache, and cost values.

## Related issue
Closes #14

## Validation
- npm.cmd test: 48/48 passed
- npm.cmd run typecheck: passed
- git diff --check: passed

## Checklist
- [x] This PR contains one cohesive change; unrelated work is split into separate PRs.
- [x] I have added or updated tests where the change requires them.
- [x] I have run the relevant tests and checks.
- [x] I have updated documentation where needed.