### PR TITLE
feat(settings): allow direct wheel speed input

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Key options:
 | --- | --- | --- |
 | `settingsLanguage` | `en`, `zh` | Changes the `/open-tui` interface language |
 | `cursorStyle` | `block`, `bar`, `underline` | `bar` and `underline` require terminal cursor-shape support |
-| `fullscreen.wheelScrollLines` | `1`-`10` | Lines scrolled per mouse-wheel notch in fullscreen mode; defaults to `4`. `/open-tui` cycles through `1`, `4`, `7`, and `10` for quick switching |
+| `fullscreen.wheelScrollLines` | `1`-`10` | Lines scrolled per mouse-wheel notch in fullscreen mode; defaults to `4`. In `/open-tui`, press Enter on this item and type a number (values are clamped to `1`-`10`) |
 | `icons.mode` | `auto`, `nerd`, `ascii` | Controls footer and telemetry icons |
 | `footerSegments` | Boolean flags | Shows or hides individual footer data |
 | `telemetry` | Boolean flags | Enables telemetry and its individual measurements |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -93,7 +93,7 @@ pi -e npm:pi-open-tui
 | --- | --- | --- |
 | `settingsLanguage` | `en`、`zh` | 切换 `/open-tui` 设置界面的语言 |
 | `cursorStyle` | `block`、`bar`、`underline` | `bar` 和 `underline` 需要终端支持光标形状转义序列 |
-| `fullscreen.wheelScrollLines` | `1`-`10` | 全屏模式下滚轮每格滚动的行数，默认值为 `4`；`/open-tui` 使用 `1`、`4`、`7`、`10` 四档快速切换 |
+| `fullscreen.wheelScrollLines` | `1`-`10` | 全屏模式下滚轮每格滚动的行数，默认值为 `4`；`/open-tui` 中在该项上按 Enter 后直接输入数字（超出范围会自动钳制到 `1`-`10`） |
 | `icons.mode` | `auto`、`nerd`、`ascii` | 控制底栏和遥测通知使用的图标 |
 | `footerSegments` | 布尔开关 | 分别控制底栏中的各项数据 |
 | `telemetry` | 布尔开关 | 控制遥测总开关和各项指标 |

--- a/extensions/open-tui/settings-command.ts
+++ b/extensions/open-tui/settings-command.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
 import {
 	Box,
+	Input,
 	Key,
 	matchesKey,
 	SelectList,
@@ -9,8 +10,10 @@ import {
 	Text,
 } from "@earendil-works/pi-tui";
 import type { CursorStyle, IconMode, OpenTuiConfig, SettingsLanguage } from "./config.ts";
-
-const WHEEL_SCROLL_PRESETS = [1, 4, 7, 10] as const;
+import {
+	DEFAULT_FULLSCREEN_WHEEL_SCROLL_LINES,
+	normalizeFullscreenWheelScrollLines,
+} from "./fullscreen-scroll.ts";
 
 interface SettingItem {
 	id: string;
@@ -26,7 +29,7 @@ const COPY = {
 	en: {
 		title: "Open TUI Settings",
 		tabs: { features: "General", icons: "Appearance", segments: "Footer", telemetry: "Telemetry" },
-		hint: "Tab/Shift+Tab/←/→: tabs · ↑/↓: move · Enter/Space: change · Esc/q: close",
+		hint: "Tab/Shift+Tab/←/→: tabs · ↑/↓: move · Enter/Space: change · Enter on wheel speed: type 1-10 · Esc/q: close",
 		labels: {
 			enabled: "Enabled",
 			language: "Language",
@@ -53,6 +56,7 @@ const COPY = {
 			off: "Off",
 			languages: { en: "English", zh: "简体中文" },
 			wheelLines: (count: number) => `${count} ${count === 1 ? "line" : "lines"} / notch`,
+			wheelPrompt: (count: number) => `Wheel scroll lines per notch, 1-10 (current: ${count}). Enter: apply · Esc: cancel`,
 			cursorStyles: { block: "Block", bar: "Bar", underline: "Underline" },
 			icons: { auto: "Auto", nerd: "Nerd", ascii: "ASCII" },
 		},
@@ -60,7 +64,7 @@ const COPY = {
 	zh: {
 		title: "Open TUI 设置",
 		tabs: { features: "常规", icons: "外观", segments: "Footer", telemetry: "遥测" },
-		hint: "Tab/Shift+Tab/←/→：切页 · ↑/↓：移动 · Enter/Space：更改 · Esc/q：关闭",
+		hint: "Tab/Shift+Tab/←/→：切页 · ↑/↓：移动 · Enter/Space：更改 · 滚轮速度项 Enter 输入 1-10 · Esc/q：关闭",
 		labels: {
 			enabled: "启用",
 			language: "语言",
@@ -87,6 +91,7 @@ const COPY = {
 			off: "关闭",
 			languages: { en: "English", zh: "简体中文" },
 			wheelLines: (count: number) => `每格 ${count} 行`,
+			wheelPrompt: (count: number) => `滚轮每格滚动行数（当前 ${count}，范围 1-10），输入后 Enter 应用 · Esc 取消`,
 			cursorStyles: { block: "块", bar: "竖线", underline: "下划线" },
 			icons: { auto: "自动", nerd: "Nerd", ascii: "ASCII" },
 		},
@@ -127,10 +132,17 @@ function cycleCursorStyle(config: OpenTuiConfig): OpenTuiConfig {
 	return { ...config, cursorStyle: next };
 }
 
-function cycleWheelScrollLines(config: OpenTuiConfig): OpenTuiConfig {
-	const current = config.fullscreen.wheelScrollLines;
-	const wheelScrollLines = WHEEL_SCROLL_PRESETS.find((value) => value > current) ?? WHEEL_SCROLL_PRESETS[0];
-	return { ...config, fullscreen: { ...config.fullscreen, wheelScrollLines } };
+function setWheelScrollLines(config: OpenTuiConfig, raw: string): OpenTuiConfig | undefined {
+	if (!/^\d+$/.test(raw)) return undefined;
+	const parsed = Number(raw);
+	const bounded = Number.isFinite(parsed) ? parsed : Number.MAX_SAFE_INTEGER;
+	return {
+		...config,
+		fullscreen: {
+			...config.fullscreen,
+			wheelScrollLines: normalizeFullscreenWheelScrollLines(bounded, DEFAULT_FULLSCREEN_WHEEL_SCROLL_LINES),
+		},
+	};
 }
 
 function toggleTelemetry(config: OpenTuiConfig, key: keyof OpenTuiConfig["telemetry"]): OpenTuiConfig {
@@ -208,7 +220,6 @@ function handleSettingChange(
 	if (tab === "features") {
 		if (itemId === "enabled") return toggleEnabled(config);
 		if (itemId === "settingsLanguage") return toggleLanguage(config);
-		if (itemId === "wheelScrollLines") return cycleWheelScrollLines(config);
 	}
 	if (tab === "icons") {
 		if (itemId === "mode") return cycleIconMode(config);
@@ -241,6 +252,7 @@ class SettingsUi implements SettingsUiHandle {
 	private cachedWidth: number | undefined;
 	private cachedLines: string[] | undefined;
 	private compact = false;
+	private wheelInput: Input | undefined;
 
 	constructor(
 		theme: Theme,
@@ -265,9 +277,33 @@ class SettingsUi implements SettingsUiHandle {
 
 	private applySetting(itemId: string): void {
 		this.selectedItemByTab[this.tab] = itemId;
+		if (this.tab === "features" && itemId === "wheelScrollLines") {
+			this.openWheelInput();
+			this.invalidate();
+			return;
+		}
 		this.config = handleSettingChange(this.tab, itemId, this.config);
 		this.onChange(this.config);
 		this.rebuild(itemId);
+	}
+
+	private openWheelInput(): void {
+		const input = new Input();
+		input.onSubmit = (value) => {
+			const next = setWheelScrollLines(this.config, value);
+			this.wheelInput = undefined;
+			if (next) {
+				this.config = next;
+				this.onChange(this.config);
+			}
+			this.rebuild("wheelScrollLines");
+		};
+		input.onEscape = () => {
+			this.wheelInput = undefined;
+			this.rebuild("wheelScrollLines");
+		};
+		this.wheelInput = input;
+		this.rebuild("wheelScrollLines");
 	}
 
 	private switchTab(offset: number): void {
@@ -289,11 +325,17 @@ class SettingsUi implements SettingsUiHandle {
 		this.container.addChild(new Text(tabBar, 1, 0));
 		this.container.addChild(new Text(this.theme.fg("dim", copy.hint), 1, 0));
 
-		const items = buildItems(this.tab, this.config).map((item) => ({
-			value: item.id,
-			label: this.compact ? `${item.label}: ${item.currentValue}` : item.label,
-			description: this.compact ? undefined : item.currentValue,
-		} as SelectItem));
+		const editingWheel = this.tab === "features" && this.wheelInput !== undefined;
+		const items = buildItems(this.tab, this.config).map((item) => {
+			const editing = editingWheel && item.id === "wheelScrollLines";
+			return {
+				value: item.id,
+				label: editing
+					? (this.compact ? `${item.label}:` : item.label)
+					: (this.compact ? `${item.label}: ${item.currentValue}` : item.label),
+				description: editing || this.compact ? undefined : item.currentValue,
+			} as SelectItem;
+		});
 		this.selectList = new SelectList(items, Math.min(items.length, 10), {
 			selectedPrefix: (t) => this.theme.fg("accent", t),
 			selectedText: (t) => this.theme.fg("accent", t),
@@ -316,12 +358,28 @@ class SettingsUi implements SettingsUiHandle {
 			this.onClose();
 		};
 		this.container.addChild(this.selectList);
+		if (editingWheel) {
+			this.wheelInput!.focused = true;
+			const wheelInputGroup = new Box(4, 0);
+			wheelInputGroup.addChild(new Text(
+				this.theme.fg("muted", copy.values.wheelPrompt(this.config.fullscreen.wheelScrollLines)),
+				0,
+				0,
+			));
+			wheelInputGroup.addChild(this.wheelInput!);
+			this.container.addChild(wheelInputGroup);
+		}
 
 		this.cachedWidth = undefined;
 		this.cachedLines = undefined;
 	}
 
 	handleInput(data: string): void {
+		if (this.wheelInput && this.tab === "features") {
+			this.wheelInput.handleInput(data);
+			this.invalidate();
+			return;
+		}
 		if (matchesKey(data, Key.tab) || matchesKey(data, Key.right)) {
 			this.switchTab(1);
 			this.invalidate();

--- a/tests/settings-command.test.ts
+++ b/tests/settings-command.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
-import { visibleWidth, type Component, type KeybindingsManager, type TUI } from "@earendil-works/pi-tui";
+import { CURSOR_MARKER, visibleWidth, type Component, type KeybindingsManager, type TUI } from "@earendil-works/pi-tui";
 import { DEFAULT_CONFIG, loadConfig, type OpenTuiConfig } from "../extensions/open-tui/config.ts";
 import { installEditor } from "../extensions/open-tui/editor.ts";
 import { getPendingUiChange } from "../extensions/open-tui/index.ts";
@@ -110,7 +110,7 @@ test("closes cleanly after enabling or disabling the UI", async () => {
 	}
 });
 
-test("updates fullscreen mouse wheel speed while settings stay open", async () => {
+test("updates fullscreen mouse wheel speed by typing a number", async () => {
 	const applied: number[] = [];
 	const settings = await openSettings(undefined, (config) => {
 		applied.push(config.fullscreen.wheelScrollLines);
@@ -120,15 +120,67 @@ test("updates fullscreen mouse wheel speed while settings stay open", async () =
 	settings.component.handleInput("\x1b[B");
 	assert.match(selectedLine(settings.component), /Mouse wheel speed/);
 
+	// Space opens the same editor without cycling the value.
 	settings.component.handleInput(" ");
-	assert.equal(settings.getConfig().fullscreen.wheelScrollLines, 7);
-	assert.deepEqual(applied, [7]);
+	assert.equal(settings.getConfig().fullscreen.wheelScrollLines, 4);
+	assert.deepEqual(applied, []);
+	assert.match(settings.component.render(80).join("\n"), /Wheel scroll lines per notch/);
+	settings.component.handleInput("\x1b");
+
+	// Enter opens the number input, type 8, Enter applies.
+	settings.component.handleInput("\r");
+	const editingLines = settings.component.render(80);
+	const parentLine = editingLines.find((line) => line.includes("→ Mouse wheel speed"));
+	const promptLine = editingLines.find((line) => line.includes("Wheel scroll lines per notch"));
+	const inputLine = editingLines.find((line) => line.includes("> "));
+	assert.ok(parentLine);
+	assert.ok(promptLine);
+	assert.ok(inputLine);
+	const parentLabelStart = parentLine.indexOf("Mouse wheel speed");
+	const promptStart = promptLine.indexOf("Wheel scroll lines per notch");
+	const inputStart = inputLine.indexOf("> ");
+	assert.equal(promptStart, parentLabelStart + 2);
+	assert.equal(inputStart, promptStart);
+	assert.ok(inputLine.includes(CURSOR_MARKER));
+	assert.match(editingLines.join("\n"), /Wheel scroll lines per notch, 1-10 \(current: 4\)/);
+	for (const width of [24, 36, 48]) {
+		for (const line of settings.component.render(width)) {
+			assert.ok(visibleWidth(line) <= width, `${visibleWidth(line)} > ${width}: ${line}`);
+		}
+	}
+	settings.component.render(80);
+	settings.component.handleInput("8");
+	settings.component.handleInput("\r");
+	assert.equal(settings.getConfig().fullscreen.wheelScrollLines, 8);
+	assert.deepEqual(applied, [8]);
 	assert.equal(settings.isClosed(), false);
 	assert.match(selectedLine(settings.component), /Mouse wheel speed/);
 
+	// Out-of-range values are clamped by normalize.
+	settings.component.handleInput("\r");
+	settings.component.handleInput("99");
+	settings.component.handleInput("\r");
+	assert.equal(settings.getConfig().fullscreen.wheelScrollLines, 10);
+
+	// Empty input is treated as cancel.
 	settings.component.handleInput("\r");
 	settings.component.handleInput("\r");
-	assert.equal(settings.getConfig().fullscreen.wheelScrollLines, 1);
+	assert.equal(settings.getConfig().fullscreen.wheelScrollLines, 10);
+	assert.deepEqual(applied, [8, 10]);
+
+	// Non-numeric input is rejected without writing a new value.
+	settings.component.handleInput("\r");
+	settings.component.handleInput("8x");
+	settings.component.handleInput("\r");
+	assert.equal(settings.getConfig().fullscreen.wheelScrollLines, 10);
+	assert.deepEqual(applied, [8, 10]);
+
+	// Esc cancels without changing the config.
+	settings.component.handleInput("\r");
+	settings.component.handleInput("\x1b");
+	assert.equal(settings.getConfig().fullscreen.wheelScrollLines, 10);
+	assert.deepEqual(applied, [8, 10]);
+	assert.match(selectedLine(settings.component), /Mouse wheel speed/);
 });
 
 test("previews cursor styles from the Appearance tab", async () => {


### PR DESCRIPTION
## Summary
Replace fullscreen wheel-speed preset cycling with direct numeric input in `/open-tui`. The prompt and input are rendered as an indented child group under the wheel-speed setting.

This supersedes PR #16, which added more preset values.

## Related issue
Supersedes #16

## Validation
- `npm test` (48/48 passing)
- `npm run typecheck`
- `git diff --check`

## Checklist
- [x] This PR contains one cohesive change; unrelated work is split into separate PRs.
- [x] I have added or updated tests where the change requires them.
- [x] I have run the relevant tests and checks.
- [x] I have updated documentation where needed.

preview:
<img width="1004" height="353" alt="image" src="https://github.com/user-attachments/assets/95c6b506-b694-4390-bc15-ed3e6fd09cdd" />