### PR TITLE
fix: detect Bun projects and use correct Nerd Font icon

### DIFF
--- a/extensions/open-tui/icons.ts
+++ b/extensions/open-tui/icons.ts
@@ -143,7 +143,7 @@ const RUNTIME_SYMBOLS: Record<string, string> = {
 	swift: "\uE755",
 	kotlin: "\uE634",
 	deno: "\uE7FB",
-	bun: "\uE6FB",
+	bun: "\uE76F",
 	php: "\uE73D",
 	haskell: "\uE777",
 	julia: "\uE624",

--- a/extensions/open-tui/runtime.ts
+++ b/extensions/open-tui/runtime.ts
@@ -21,6 +21,7 @@ interface RuntimeDef {
 }
 
 const RUNTIMES: readonly RuntimeDef[] = [
+	{ name: "bun", files: ["bun.lock", "bun.lockb"], versionCommand: { cmd: "bun", args: ["--version"], pattern: /(\d+\.\d+\.\d+)/ } },
 	{ name: "nodejs", files: ["package.json", ".nvmrc", ".node-version"], versionCommand: { cmd: "node", args: ["--version"], pattern: /v(\d+\.\d+\.\d+)/ } },
 	{ name: "rust", files: ["Cargo.toml"], versionCommand: { cmd: "rustc", args: ["--version"], pattern: /rustc\s+(\d+\.\d+\.\d+)/ } },
 	{ name: "go", files: ["go.mod"], versionCommand: { cmd: "go", args: ["version"], pattern: /go(\d+\.\d+\.\d+)/ } },
@@ -32,7 +33,6 @@ const RUNTIMES: readonly RuntimeDef[] = [
 	{ name: "cpp", files: ["CMakeLists.txt", "Makefile"] },
 	{ name: "c", files: ["Makefile", "CMakeLists.txt"] },
 	{ name: "deno", files: ["deno.json", "deno.jsonc", "deno.lock"], versionCommand: { cmd: "deno", args: ["--version"], pattern: /deno\s+(\d+\.\d+\.\d+)/ } },
-	{ name: "bun", files: ["bun.lock", "bun.lockb"], versionCommand: { cmd: "bun", args: ["--version"], pattern: /(\d+\.\d+\.\d+)/ } },
 	{ name: "php", files: ["composer.json"], versionCommand: { cmd: "php", args: ["--version"], pattern: /PHP\s+(\d+\.\d+\.\d+)/ } },
 	{ name: "haskell", files: ["stack.yaml", "cabal.project", ".cabal"], versionCommand: { cmd: "ghc", args: ["--version"], pattern: /(\d+\.\d+\.\d+)/ } },
 	{ name: "julia", files: ["Project.toml", "Manifest.toml"], versionCommand: { cmd: "julia", args: ["--version"], pattern: /julia\s+(\d+\.\d+\.\d+)/ } },

--- a/tests/footer.test.ts
+++ b/tests/footer.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import type {
 	ExtensionContext,
@@ -9,7 +12,8 @@ import type { Component, TUI } from "@earendil-works/pi-tui";
 import { DEFAULT_CONFIG } from "../extensions/open-tui/config.ts";
 import { installFooter } from "../extensions/open-tui/footer.ts";
 import { emptyGitStatus } from "../extensions/open-tui/git.ts";
-import { resolveGlyphs } from "../extensions/open-tui/icons.ts";
+import { resolveGlyphs, runtimeSymbol } from "../extensions/open-tui/icons.ts";
+import { clearRuntimeCache, readRuntimeInfo } from "../extensions/open-tui/runtime.ts";
 import { getUsageTotals, invalidateUsageCache, type FooterState } from "../extensions/open-tui/state.ts";
 import { fitSegmentsByPriority, truncateBranch, truncatePath } from "../extensions/open-tui/utils.ts";
 
@@ -172,6 +176,36 @@ test("both icon modes provide every footer semantic", () => {
 	for (const mode of ["nerd", "ascii"] as const) {
 		const glyphs = resolveGlyphs(mode);
 		for (const key of keys) assert.notEqual(glyphs[key], "", `${mode}.${key}`);
+	}
+});
+
+test("uses the official Nerd Font runtime symbols", () => {
+	assert.equal(runtimeSymbol("nodejs", "nerd"), "\uE718");
+	assert.equal(runtimeSymbol("bun", "nerd"), "\uE76F");
+	assert.equal(runtimeSymbol("bun", "ascii"), "bun");
+});
+
+test("prefers Bun lockfiles while preserving the Node fallback", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "open-tui-runtime-"));
+	try {
+		writeFileSync(join(cwd, "package.json"), "{}");
+		assert.equal((await readRuntimeInfo(cwd))?.name, "nodejs");
+
+		writeFileSync(join(cwd, "package-lock.json"), "{}");
+		assert.equal((await readRuntimeInfo(cwd))?.name, "nodejs");
+
+		writeFileSync(join(cwd, "bun.lock"), "");
+		assert.equal((await readRuntimeInfo(cwd))?.name, "bun");
+
+		rmSync(join(cwd, "bun.lock"));
+		writeFileSync(join(cwd, "bun.lockb"), "");
+		assert.equal((await readRuntimeInfo(cwd))?.name, "bun");
+
+		rmSync(join(cwd, "bun.lockb"));
+		assert.equal((await readRuntimeInfo(cwd))?.name, "nodejs");
+	} finally {
+		clearRuntimeCache();
+		rmSync(cwd, { recursive: true, force: true });
 	}
 });
 


### PR DESCRIPTION
## Summary
- prefer Bun-specific lockfiles over the generic Node.js `package.json` fallback
- use the official Nerd Fonts `dev-bun` glyph at `U+E76F`
- cover Bun/Node lockfile transitions and runtime symbols with regression tests

## Related issue
Closes #21

## Validation
- `node --test --test-reporter=tap tests/settings-command.test.ts tests/fullscreen-scroll.test.ts tests/footer.test.ts tests/editor.test.ts tests/telemetry.test.ts` (52 passed)
- `npm run typecheck`
- `git diff --check`

## Checklist
- [x] This PR contains one cohesive change; unrelated work is split into separate PRs.
- [x] I have added or updated tests where the change requires them.
- [x] I have run the relevant tests and checks.
- [x] I have updated documentation where needed. No documentation changes were required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 优化 Bun 运行时识别，在多种运行时同时匹配时优先识别 Bun。
  * 更新 Bun 的 Nerd Font 图标显示，并保留 ASCII 回退显示。

* **错误修复**
  * 修复 Bun 项目图标及运行时检测优先级不正确的问题。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->