### PR TITLE
fix: include tool result usage in footer totals

### DIFF
--- a/extensions/open-tui/state.ts
+++ b/extensions/open-tui/state.ts
@@ -1,5 +1,5 @@
+import type { Usage } from "@earendil-works/pi-ai";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
-import type { AssistantMessage } from "@earendil-works/pi-ai";
 import type { GitStatus } from "./git.ts";
 import { emptyGitStatus } from "./git.ts";
 import type { RuntimeInfo } from "./runtime.ts";
@@ -39,24 +39,32 @@ export function getUsageTotals(ctx: ExtensionContext): UsageTotals {
 		latestCacheHitRate: undefined,
 	};
 	for (const entry of ctx.sessionManager.getEntries()) {
-		if (entry.type === "message" && entry.message?.role === "assistant") {
-			const m = entry.message as AssistantMessage;
-			const u = m.usage;
-			if (!u) continue;
-			const input = finiteOrZero(u.input);
-			const cacheRead = finiteOrZero(u.cacheRead);
-			const cacheWrite = finiteOrZero(u.cacheWrite);
-			// input matches /session's "uncached" total: cacheWrite is billed near full
-			// price (fresh content), only cacheRead is discounted repeat content.
-			totals.input += input + cacheWrite;
-			totals.output += finiteOrZero(u.output);
-			totals.cacheRead += cacheRead;
-			totals.cacheWrite += cacheWrite;
-			totals.cost += finiteOrZero(u.cost?.total);
+		let u: Usage | undefined;
+		let updateCacheHitRate = false;
+		if (entry.type === "message" && entry.message.role === "assistant") {
+			u = entry.message.usage;
+			updateCacheHitRate = true;
+		} else if (entry.type === "message" && entry.message.role === "toolResult") {
+			u = entry.message.usage;
+		} else if (entry.type === "branch_summary" || entry.type === "compaction") {
+			u = entry.usage;
+		}
+		if (!u) continue;
+		const input = finiteOrZero(u.input);
+		const cacheRead = finiteOrZero(u.cacheRead);
+		const cacheWrite = finiteOrZero(u.cacheWrite);
+		// input matches /session's "uncached" total: cacheWrite is billed near full
+		// price (fresh content), only cacheRead is discounted repeat content.
+		totals.input += input + cacheWrite;
+		totals.output += finiteOrZero(u.output);
+		totals.cacheRead += cacheRead;
+		totals.cacheWrite += cacheWrite;
+		totals.cost += finiteOrZero(u.cost?.total);
+		if (updateCacheHitRate) {
 			const promptTokens = input + cacheRead + cacheWrite;
-			if (promptTokens > 0) {
-				totals.latestCacheHitRate = (cacheRead / promptTokens) * 100;
-			}
+			totals.latestCacheHitRate = promptTokens > 0
+				? (cacheRead / promptTokens) * 100
+				: undefined;
 		}
 	}
 	usageCache = { key, totals };

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,9 @@
         "typescript": "^5.5.0"
       },
       "peerDependencies": {
-        "@earendil-works/pi-ai": ">=0.80",
-        "@earendil-works/pi-coding-agent": ">=0.80",
-        "@earendil-works/pi-tui": ">=0.80"
+        "@earendil-works/pi-ai": ">=0.81",
+        "@earendil-works/pi-coding-agent": ">=0.81",
+        "@earendil-works/pi-tui": ">=0.81"
       },
       "peerDependenciesMeta": {
         "@earendil-works/pi-ai": {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "image": "https://raw.githubusercontent.com/OldSuns/pi-open-tui/main/assets/preview_dashboard_1.png"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": ">=0.80",
-    "@earendil-works/pi-ai": ">=0.80",
-    "@earendil-works/pi-tui": ">=0.80"
+    "@earendil-works/pi-coding-agent": ">=0.81",
+    "@earendil-works/pi-ai": ">=0.81",
+    "@earendil-works/pi-tui": ">=0.81"
   },
   "peerDependenciesMeta": {
     "@earendil-works/pi-coding-agent": {

--- a/tests/footer.test.ts
+++ b/tests/footer.test.ts
@@ -253,6 +253,49 @@ test("usage totals count cache-write tokens as input, matching /session's uncach
 	invalidateUsageCache();
 });
 
+test("usage totals include tool result and summary usage", () => {
+	const entries = [
+		{
+			id: "assistant-usage",
+			timestamp: 1,
+			type: "message",
+			message: {
+				role: "assistant",
+				usage: { input: 90, output: 12, cacheRead: 5000, cacheWrite: 27009, cost: { total: 0.01 } },
+			},
+		},
+		{
+			id: "tool-usage",
+			timestamp: 2,
+			type: "message",
+			message: {
+				role: "toolResult",
+				usage: { input: 40, output: 8, cacheRead: 100, cacheWrite: 20, cost: { total: 0.02 } },
+			},
+		},
+		{
+			id: "compaction-usage",
+			timestamp: 3,
+			type: "compaction",
+			usage: { input: 7, output: 3, cacheRead: 200, cacheWrite: 5, cost: { total: 0.03 } },
+		},
+		{
+			id: "branch-summary-usage",
+			timestamp: 4,
+			type: "branch_summary",
+			usage: { input: 11, output: 4, cacheRead: 300, cacheWrite: 9, cost: { total: 0.04 } },
+		},
+	];
+	const ctx = { sessionManager: { getEntries: () => entries } } as unknown as ExtensionContext;
+
+	invalidateUsageCache();
+	assert.deepEqual(getUsageTotals(ctx), {
+		input: 27_191, output: 27, cacheRead: 5_600, cacheWrite: 27_043, cost: 0.1,
+		latestCacheHitRate: (5000 / 32_099) * 100,
+	});
+	invalidateUsageCache();
+});
+
 test("ASCII footer renders icons as semantic labels", () => {
 	let footerFactory: NonNullable<Parameters<ExtensionContext["ui"]["setFooter"]>[0]> | undefined;
 	const entries = [{


### PR DESCRIPTION
## Summary / Problem

The footer usage totals only included assistant messages. Tool results can also carry usage reported by the coding agent, so sessions with subagent or tool work showed lower token counts and costs than Pi's built-in session totals.

## Changes

- Include usage from `toolResult` messages in the existing footer aggregation.
- Add a regression test covering combined assistant and tool-result token, cache, and cost totals.

## Tests

- `npm test` (53 passed)
- `npm run typecheck` (passed)
- `git diff --check` (passed)

## Compatibility / Known limitations

Assistant-message handling and existing invalid-value normalization remain unchanged. This change uses the optional usage already persisted on tool-result messages; entries without usage continue to be ignored.

Fixes #24


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复用量统计不完整的问题。
  * 现在会汇总助手回复、工具结果、分支摘要及压缩记录中的输入、输出、缓存读写和费用数据。
  * 当没有提示词令牌时，缓存命中率会正确重置，避免显示过期数据。
  * 缓存命中率仅根据适用的助手回复数据更新。

* **Tests**
  * 增加并扩展用量汇总测试，覆盖多种记录类型及相关统计指标。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->