### PR TITLE
fix: avoid clearing terminal during session resume

### DIFF
--- a/extensions/open-tui/index.ts
+++ b/extensions/open-tui/index.ts
@@ -15,28 +15,11 @@ import {
 	type FooterState,
 } from "./state.ts";
 
-function isInteractiveLaunch(): boolean {
-	if (!process.stdout.isTTY) return false;
-	const args = process.argv.slice(2);
-	const nonInteractiveFlags = ["-p", "--print", "--help", "-h", "--version", "-v", "--list-models", "--export"];
-	for (const arg of args) {
-		if (nonInteractiveFlags.includes(arg)) return false;
-		if (arg.startsWith("--mode")) return false;
-	}
-	return true;
-}
-
 type PendingUiChange = "install" | "uninstall";
 
 export function getPendingUiChange(enabled: boolean, active: boolean): PendingUiChange | undefined {
 	if (enabled === active) return undefined;
 	return enabled ? "install" : "uninstall";
-}
-
-function clearVisibleScreen(): void {
-	if (process.stdout.isTTY) {
-		process.stdout.write("\x1b[2J\x1b[H");
-	}
 }
 
 function isTuiContext(ctx: ExtensionContext): boolean {
@@ -173,10 +156,6 @@ export default function (pi: ExtensionAPI) {
 
 		ensureConfigExists();
 		config = loadConfig((msg, level) => ctx.ui.notify(msg, level));
-
-		if (isInteractiveLaunch() && config.enabled) {
-			clearVisibleScreen();
-		}
 
 		applyUi(ctx);
 


### PR DESCRIPTION
   ## Summary                                                                                                                                                                                
                                                                                                                                                                                             
   When resuming or switching sessions, `pi-open-tui` directly cleared the terminal with:                                                                                                    
                                                                                                                                                                                             
```ts                                                                                                                                                                                     
   process.stdout.write("\x1b[2J\x1b[H");                                                                                                                                                    
 ```                                                                                                                                                                                         
                                                                                                                                                                                             
 This bypassed Pi's differential renderer and synchronized output, causing a visible blank frame before the new session was rendered. It also left Pi's internal render cache out of sync    
 with the actual terminal contents.                                                                                                                                                          
                                                                                                                                                                                             
 This PR removes the raw screen-clear logic and lets Pi's native TUI renderer manage session transitions.                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                             
   ## Validation                                                                                                                                                                             
                                                                                                                                                                                             
   - `npm test` — 53 tests passed                                                                                                                                                            
   - `npm run typecheck` — passed                                                                                                                                                            
   - `git diff --check` — passed                                                                                                                                                             
   - Manually verified that session resume no longer clears the terminal before rendering 
   - No additional automated test was added because this is a terminal rendering integration fix. Existing tests and manual verification pass.                                                                                                    
                                                                                                                                                                                             
   ## Checklist                                                                                                                                                                              
                                                                                                                                                                                             
   - [x] This PR contains one cohesive change; unrelated work is split into separate PRs.                                                                                                    
   - [ ] I have added or updated tests where the change requires them.                                                                                                                       
   - [x] I have run the relevant tests and checks.                                                                                                                                           
   - [x] I have updated documentation where needed.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Interactive TUI sessions no longer automatically clear the visible screen when starting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->