### PR TITLE
feat: add thinking peek ticker above the editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A polished terminal interface for the [Pi](https://pi.dev) coding agent. It brin
 - **Framed editor** with block, bar, and underline cursor styles
 - **Project awareness** for 50+ runtimes and detailed Git states, including ahead/behind, staged, modified, untracked, stashed, and detached HEAD
 - **Turn telemetry** for TPS, time to first token (TTFT), duration, stalls, tokens, and list-price rate
+- **Thinking peek**: an inline ticker replaces Pi's hidden `Thinking...` label with the tail of the model's reasoning while it works
 - **Interactive settings** through `/open-tui`, available in English and Simplified Chinese
 - **Version-guarded Pi compatibility shim**: fullscreen wheel speed falls back to Pi's default if its runtime support changes
 
@@ -83,6 +84,9 @@ Run `/open-tui` to open the settings dialog. It provides **General**, **Appearan
     "tokens": true,
     "stalls": true,
     "cost": true
+  },
+  "thinkingPeek": {
+    "lines": 1
   }
 }
 ```
@@ -97,6 +101,7 @@ Key options:
 | `icons.mode` | `auto`, `nerd`, `ascii` | Controls footer and telemetry icons |
 | `footerSegments` | Boolean flags | Shows or hides individual footer data |
 | `telemetry` | Boolean flags | Enables telemetry and its individual measurements |
+| `thinkingPeek.lines` | `0`, `1`, `2` | Off, one-line, or two-line hidden thinking preview |
 
 `sessionName` appears only when the session has a name. `gitCommit` shows the short hash and tag in detached HEAD state. Disabling `extensionStatuses` hides the entire extension status line, including MCP status.
 
@@ -113,6 +118,22 @@ After each complete agent run, pi-open-tui shows one transient result. Tool-call
 TPS is calculated from all provider-reported assistant output tokens divided by the total generation time across the run. Timing starts at `turn_start` and ends at the assistant `message_end`, so it includes TTFT, hidden reasoning, buffering, and stalls; tool execution between turns is excluded. Runs without output tokens or measurable generation time show `TPS —`.
 
 The `$ / M` value is the model's list-price rate from `usage.cost.total`, not the cumulative session cost shown in the footer. Every telemetry field can be toggled from the **Telemetry** tab.
+
+## Thinking peek
+
+When Pi's **Hide thinking** setting is enabled, pi-open-tui shows a compact ticker in the native hidden thinking block's `Thinking...` position. The `/open-tui` setting offers three modes: **Off**, **1 line**, and **2 lines**.
+
+- while the model is reasoning, the current thinking tail streams by with a spinner (`~ think ⠋ …`);
+- when the answer starts, it settles on a check mark (`~ think ✓`);
+- in 2-line mode, the previous and latest thinking lines share the same text indentation; if the latest line overflows, both rows are used for its continuation instead of retaining the previous line;
+- after the task settles, the native `Thinking...` label is restored.
+
+```text
+~ think ⠋ previous thought
+          latest thought
+```
+
+The ticker appears only once the model actually streams reasoning, so non-reasoning models never show it. Pi's own Hide thinking toggle controls visibility; changing it takes effect immediately. Each row is truncated by *visible* width, so CJK-wide thinking text cannot overflow. Configure it from **General → Thinking peek** in `/open-tui`, or via `thinkingPeek.lines` in `open-tui.json`.
 
 ## Local development
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,6 +13,7 @@
 - **带边框的编辑器**：支持块状、竖线和下划线三种光标样式
 - **项目环境感知**：识别 50 多种运行环境，并展示 ahead/behind、已暂存、已修改、未跟踪、stash 和 detached HEAD 等 Git 状态
 - **单轮遥测**：展示 TPS、首 Token 延迟（TTFT）、耗时、停顿、Token 数量和模型标价速率
+- **思考预览**：模型工作时，在 Pi 隐藏思考块的 `Thinking...` 位置显示实时字幕，展示推理内容的末尾片段
 - **交互式设置**：通过 `/open-tui` 配置，并支持英文和简体中文界面
 - **带版本保护的 Pi 兼容层**：全屏滚轮速度所依赖的运行时支持发生变化时，会回退为 Pi 默认行为
 
@@ -83,6 +84,9 @@ pi -e npm:pi-open-tui
     "tokens": true,
     "stalls": true,
     "cost": true
+  },
+  "thinkingPeek": {
+    "lines": 1
   }
 }
 ```
@@ -97,6 +101,7 @@ pi -e npm:pi-open-tui
 | `icons.mode` | `auto`、`nerd`、`ascii` | 控制底栏和遥测通知使用的图标 |
 | `footerSegments` | 布尔开关 | 分别控制底栏中的各项数据 |
 | `telemetry` | 布尔开关 | 控制遥测总开关和各项指标 |
+| `thinkingPeek.lines` | `0`、`1`、`2` | 关闭、单行或双行思考预览 |
 
 `sessionName` 仅在会话有名称时显示；`gitCommit` 会在 detached HEAD 状态下显示短哈希和标签；关闭 `extensionStatuses` 会隐藏整行扩展状态，其中也包括 MCP 状态。
 
@@ -113,6 +118,22 @@ pi -e npm:pi-open-tui
 TPS 的计算方式是：将本次运行中服务商报告的全部 Assistant 输出 Token，除以各个生成轮次的总耗时。计时范围从 `turn_start` 到 Assistant 的 `message_end`，包含 TTFT、隐藏推理、缓冲和停顿，但不包含轮次之间的工具执行时间。没有输出 Token 或无法测得生成时间时，会显示 `TPS —`。
 
 `$ / M` 表示根据 `usage.cost.total` 得到的模型标价速率，不是底栏中的会话累计费用。所有遥测字段都可以在**遥测**页单独开关。
+
+## 思考预览
+
+开启 Pi 的 **Hide thinking** 后，任务运行期间 pi-open-tui 会在原生隐藏思考块的 `Thinking...` 位置显示紧凑的实时字幕。`/open-tui` 中提供**关闭、单行、双行**三种模式：
+
+- 模型推理时，思考内容的末尾片段会随 spinner 滚动（`~ think ⠋ …`）；
+- 开始输出正文时定格为对勾（`~ think ✓`）；
+- 双行模式中，上一条和最新一条思考内容使用相同的文字缩进；如果最新一行超出宽度，则两行都用于显示它的连续内容，不再保留上一条；
+- 任务结束后恢复原生 `Thinking...` 标签。
+
+```text
+~ think ⠋ 上一条思考
+          最新一条思考
+```
+
+该字幕仅在模型真正输出推理内容后出现，非推理模型不会显示。可见性由 Pi 自身的 Hide thinking 开关控制，切换后立即生效。每一行都按*显示宽度*截断（全角字符计 2 列），因此包含中文的思考文本也不会溢出终端。可在 `/open-tui` 的**常规 → 思考预览**中切换，或直接修改 `open-tui.json` 中的 `thinkingPeek.lines`。
 
 ## 本地开发
 

--- a/extensions/open-tui/config.ts
+++ b/extensions/open-tui/config.ts
@@ -9,6 +9,7 @@ import type { IconMode } from "./icons.ts";
 
 export type SettingsLanguage = "en" | "zh";
 export type CursorStyle = "block" | "bar" | "underline";
+export type ThinkingPeekLines = 0 | 1 | 2;
 
 export type { IconMode } from "./icons.ts";
 
@@ -35,6 +36,10 @@ export interface TelemetryConfig {
 	cost: boolean;
 }
 
+export interface ThinkingPeekConfig {
+	lines: ThinkingPeekLines;
+}
+
 export interface FullscreenConfig {
 	wheelScrollLines: number;
 }
@@ -49,6 +54,7 @@ export interface OpenTuiConfig {
 	};
 	footerSegments: FooterSegments;
 	telemetry: TelemetryConfig;
+	thinkingPeek: ThinkingPeekConfig;
 }
 
 export const DEFAULT_CONFIG: OpenTuiConfig = {
@@ -82,11 +88,18 @@ export const DEFAULT_CONFIG: OpenTuiConfig = {
 		stalls: true,
 		cost: true,
 	},
+	thinkingPeek: {
+		lines: 1,
+	},
 };
 
 export function getConfigPath(): string {
 	const agentDir = getAgentDir();
 	return join(agentDir, "open-tui.json");
+}
+
+function normalizeThinkingPeekLines(value: unknown): ThinkingPeekLines {
+	return value === 0 || value === 1 || value === 2 ? value : DEFAULT_CONFIG.thinkingPeek.lines;
 }
 
 function deepMerge<T>(base: T, override: unknown): T {
@@ -144,6 +157,11 @@ export function loadConfig(notify?: (msg: string, level: "warning" | "info") => 
 			config.fullscreen.wheelScrollLines,
 			DEFAULT_CONFIG.fullscreen.wheelScrollLines,
 		);
+		if (typeof config.thinkingPeek !== "object" || config.thinkingPeek === null || Array.isArray(config.thinkingPeek)) {
+			config.thinkingPeek = structuredClone(DEFAULT_CONFIG.thinkingPeek);
+		} else {
+			config.thinkingPeek.lines = normalizeThinkingPeekLines(config.thinkingPeek.lines);
+		}
 		return config;
 	} catch (err) {
 		notify?.(`open-tui config parse error: ${err instanceof Error ? err.message : String(err)}`, "warning");

--- a/extensions/open-tui/index.ts
+++ b/extensions/open-tui/index.ts
@@ -14,6 +14,14 @@ import {
 	invalidateUsageCache,
 	type FooterState,
 } from "./state.ts";
+import { resolveGlyphs } from "./icons.ts";
+import {
+	buildPeekLabel,
+	collectPeekParts,
+	createPeekState,
+	reducePeek,
+	type PeekState,
+} from "./peek.ts";
 
 function isInteractiveLaunch(): boolean {
 	if (!process.stdout.isTTY) return false;
@@ -63,8 +71,95 @@ export default function (pi: ExtensionAPI) {
 	let editor: ReturnType<typeof installEditor> | undefined;
 	let pendingUiChange: PendingUiChange | undefined;
 
+	// thinking-peek state (rendered by Pi inside its hidden-thinking block)
+	const peek: PeekState = createPeekState();
+	let peekFrame = 0;
+	let peekTimer: ReturnType<typeof setInterval> | undefined;
+	let peekSettleTimer: ReturnType<typeof setTimeout> | undefined;
+	let peekTaskEpoch = 0; // bumped at every agent task boundary
+	let peekLabelActive = false;
+
 	const getThinkingLevel = () => (sessionLifecycle.isCurrent() ? pi.getThinkingLevel() : "off");
 
+	/** True while the agent is running (false during session-restore replay). */
+	const isAgentIdle = (ctx: ExtensionContext): boolean => {
+		try {
+			return (ctx as ExtensionContext & { isIdle?: () => boolean }).isIdle?.() === true;
+		} catch {
+			return false;
+		}
+	};
+
+	/** Pi decides whether this label is visible; our toggle only controls updates. */
+	const isPeekEnabled = () => sessionLifecycle.isCurrent() && config.enabled && config.thinkingPeek.lines > 0 && active;
+
+	/** Keep each native hidden-thinking label row within Pi's padded width. */
+	const hiddenThinkingLabelWidth = (): number => {
+		const columns = process.stdout.columns;
+		// ponytail: use stdout width; Pi does not expose the transcript width here.
+		return typeof columns === "number" && Number.isFinite(columns)
+			? Math.max(1, columns - 2)
+			: 78;
+	};
+
+	const setPeekLabel = (ctx?: ExtensionContext): void => {
+		if (!isPeekEnabled() || peek.phase === "idle") return;
+		const target = ctx ?? lastCtx;
+		if (!target || !isTuiContext(target)) return;
+		// ponytail: Pi exposes one global hidden-thinking label; per-message updates
+		// need an upstream renderer hook.
+		target.ui.setHiddenThinkingLabel(
+			buildPeekLabel(
+				peek,
+				peekFrame,
+				resolveGlyphs(config.icons.mode),
+				hiddenThinkingLabelWidth(),
+				config.thinkingPeek.lines,
+			),
+		);
+		peekLabelActive = true;
+	};
+
+	const clearPeekLabel = (ctx?: ExtensionContext): void => {
+		if (!peekLabelActive) return;
+		const target = ctx ?? lastCtx;
+		if (!target || !isTuiContext(target)) return;
+		target.ui.setHiddenThinkingLabel();
+		peekLabelActive = false;
+	};
+
+	/** Drive the peek spinner at ~8fps while the model is reasoning. */
+	const startPeekTimer = () => {
+		if (peekTimer) return;
+		const tick = () => {
+			if (!sessionLifecycle.isCurrent() || !isPeekEnabled() || peek.phase !== "thinking") return;
+			peekFrame++;
+			// ponytail: sample at ~8fps because Pi rebuilds every assistant component
+			// when its global hidden-thinking label changes.
+			setPeekLabel();
+		};
+		peekTimer = setInterval(tick, 120);
+		peekTimer.unref?.();
+	};
+
+	/** Freeze the peek spinner (used when reasoning ends for this sub-message). */
+	const stopPeekTimer = () => {
+		if (peekTimer) {
+			clearInterval(peekTimer);
+			peekTimer = undefined;
+		}
+	};
+
+	/** Reset peek state to idle and cancel any scheduled cleanup. */
+	const resetPeek = () => {
+		peek.phase = "idle";
+		peek.tail = "";
+		stopPeekTimer();
+		if (peekSettleTimer) {
+			clearTimeout(peekSettleTimer);
+			peekSettleTimer = undefined;
+		}
+	};
 	const applyUi = (ctx: ExtensionContext) => {
 		if (!isTuiContext(ctx)) return;
 		if (!config.enabled) {
@@ -102,6 +197,8 @@ export default function (pi: ExtensionAPI) {
 			cleanupFooter = undefined;
 			editor = undefined;
 			requestFooterRender = undefined;
+			resetPeek();
+			clearPeekLabel(ctx);
 			active = false;
 		}
 	};
@@ -173,6 +270,7 @@ export default function (pi: ExtensionAPI) {
 
 		ensureConfigExists();
 		config = loadConfig((msg, level) => ctx.ui.notify(msg, level));
+		clearPeekLabel(ctx);
 
 		if (isInteractiveLaunch() && config.enabled) {
 			clearVisibleScreen();
@@ -195,6 +293,9 @@ export default function (pi: ExtensionAPI) {
 	pi.on("agent_start", (event, _ctx) => {
 		turnTelemetry.handle(event);
 		if (!sessionLifecycle.isCurrent()) return;
+		// agent_start also covers custom-message and continuation-triggered tasks
+		// that do not emit a user message_start event.
+		peekTaskEpoch++;
 		state.workingSince = Date.now();
 		state.lastDoneIn = undefined;
 		startWorkingTimer();
@@ -214,12 +315,41 @@ export default function (pi: ExtensionAPI) {
 		turnTelemetry.handle(event);
 	});
 
-	pi.on("message_start", (event) => {
+	pi.on("message_start", (event, ctx) => {
 		turnTelemetry.handle(event);
+		if (!sessionLifecycle.isCurrent() || isAgentIdle(ctx)) return;
+		const role = event.message?.role;
+		if (role === "user") {
+			// Restore Pi's native label until real thinking arrives. The task epoch is
+			// advanced by agent_start so custom/no-user tasks are covered too.
+			resetPeek();
+			clearPeekLabel(ctx);
+		} else if (role === "assistant") {
+			resetPeek();
+			clearPeekLabel(ctx);
+		}
 	});
 
-	pi.on("message_update", (event) => {
+	pi.on("message_update", (event, ctx) => {
 		turnTelemetry.handle(event);
+		if (!sessionLifecycle.isCurrent() || isAgentIdle(ctx)) return;
+		if (!isPeekEnabled()) return;
+		const message = event.message;
+		if (!message || message.role !== "assistant") return;
+		const parts = collectPeekParts(message.content);
+		const previousPhase = peek.phase;
+		const next = reducePeek(peek, parts);
+		const changed = next.phase !== peek.phase || next.tail !== peek.tail;
+		peek.phase = next.phase;
+		peek.tail = next.tail;
+		if (!changed) return;
+		if (peek.phase === "thinking") {
+			startPeekTimer();
+			if (!peekLabelActive) setPeekLabel(ctx);
+		} else {
+			stopPeekTimer();
+			if (peek.phase === "done" && previousPhase !== "done") setPeekLabel(ctx);
+		}
 	});
 
 	pi.on("tool_execution_start", (event) => {
@@ -236,6 +366,15 @@ export default function (pi: ExtensionAPI) {
 			const message = formatTurnTelemetry(telemetry, ctx.ui.theme, config.telemetry, config.icons.mode);
 			if (message) ctx.ui.notify(message, "info");
 		}
+		// Only clear the peek label when this task is still the current one.
+		const settleEpoch = peekTaskEpoch;
+		if (peekSettleTimer) clearTimeout(peekSettleTimer);
+		peekSettleTimer = setTimeout(() => {
+			peekSettleTimer = undefined;
+			if (!sessionLifecycle.isCurrent() || peekTaskEpoch !== settleEpoch) return;
+			resetPeek();
+			clearPeekLabel(ctx);
+		}, 300);
 	});
 
 	pi.on("model_select", (_event, ctx) => {
@@ -249,6 +388,12 @@ export default function (pi: ExtensionAPI) {
 	pi.on("message_end", (event, ctx) => {
 		turnTelemetry.handle(event);
 		if (!sessionLifecycle.isCurrent()) return;
+		if (event.message?.role === "assistant" && peek.phase === "thinking") {
+			// Sub-message finished (answer text or a tool call): freeze the peek line.
+			peek.phase = "done";
+			stopPeekTimer();
+			setPeekLabel(ctx);
+		}
 		invalidateUsageCache();
 		refreshInteractiveState(ctx);
 	});
@@ -274,8 +419,15 @@ export default function (pi: ExtensionAPI) {
 		onConfigChanged: (newConfig) => {
 			const cursorStyleChanged = config.cursorStyle !== newConfig.cursorStyle;
 			const wheelScrollLinesChanged = config.fullscreen.wheelScrollLines !== newConfig.fullscreen.wheelScrollLines;
+			const thinkingPeekLinesChanged = config.thinkingPeek.lines !== newConfig.thinkingPeek.lines;
 			saveConfig(newConfig);
 			config = newConfig;
+			if (newConfig.thinkingPeek.lines === 0 || !newConfig.enabled) {
+				resetPeek();
+				clearPeekLabel(lastCtx);
+			} else if (thinkingPeekLinesChanged && peekLabelActive) {
+				setPeekLabel(lastCtx);
+			}
 			if (cursorStyleChanged && active && editor) {
 				editor.setCursorStyle(newConfig.cursorStyle);
 			}

--- a/extensions/open-tui/peek.ts
+++ b/extensions/open-tui/peek.ts
@@ -1,0 +1,165 @@
+import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import type { IconGlyphs } from "./icons.ts";
+import { sanitizeStatus } from "./utils.ts";
+
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const MAX_PEEK_LINES = 2;
+
+export type PeekPhase = "idle" | "thinking" | "done";
+
+export interface PeekState {
+	phase: PeekPhase;
+	tail: string;
+}
+
+export interface PeekMessageParts {
+	thinking: string;
+	text: string;
+}
+
+function stringValue(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+const normalizePeekLineCount = (lineCount: number): number => Math.max(1, Math.min(MAX_PEEK_LINES, Math.floor(lineCount)));
+
+/**
+ * Pure phase machine for one assistant-message update.
+ *
+ * Thinking text is cumulative: once the answer starts, later updates still
+ * carry the full thinking block alongside new text. To keep the spinner honest:
+ * - idle + thinking        -> thinking (spinner starts)
+ * - idle + thinking + text -> done    (already answered, never spin)
+ * - thinking + text        -> done    (answer started: stop spinner)
+ * - done + thinking        -> done    (never restart the spinner)
+ * - any + text only        -> idle stays idle (plain answer, nothing to peek)
+ */
+export function reducePeek(prev: PeekState, parts: PeekMessageParts): PeekState {
+	const tail = parts.thinking ? peekTail(parts.thinking, MAX_PEEK_LINES) : prev.tail;
+	let phase = prev.phase;
+	if (parts.thinking && phase === "idle") phase = "thinking";
+	if (parts.text && phase === "thinking") phase = "done";
+	return { phase, tail };
+}
+
+/** Fresh peek state (no task running yet). */
+export function createPeekState(): PeekState {
+	return { phase: "idle", tail: "" };
+}
+
+/**
+ * Collect the running thinking text and answer text from an assistant
+ * message's content parts. Thinking arrives token-by-token, so re-calling
+ * this on every `message_update` yields the cumulative text.
+ */
+export function collectPeekParts(content: unknown): PeekMessageParts {
+	let thinking = "";
+	let text = "";
+	if (!Array.isArray(content)) return { thinking, text };
+	for (const rawPart of content) {
+		if (!rawPart || typeof rawPart !== "object") continue;
+		const part = rawPart as { type?: unknown; thinking?: unknown; text?: unknown };
+		if (part.type === "thinking") {
+			thinking += stringValue(part.thinking) ?? stringValue(part.text) ?? "";
+		} else if (part.type === "text") {
+			text += stringValue(part.text) ?? "";
+		}
+	}
+	return { thinking, text };
+}
+
+/**
+ * Extract the last non-empty logical lines of the thinking text, whitespace-
+ * normalized. NOT width-bounded: clipping to the terminal happens at render
+ * time in buildPeekLabel/clipTail, so wide terminals get to see more of it.
+ */
+export function peekTail(fullThinking: string, lineCount = 1): string {
+	if (!fullThinking) return "";
+	const count = normalizePeekLineCount(lineCount);
+	const lines = fullThinking
+		.split("\n")
+		.map((line) => line.replace(/\s+/g, " ").trim())
+		.filter(Boolean);
+	return lines.slice(-count).join("\n");
+}
+
+/**
+ * Clip a tail string to `budget` visible columns, keeping the END (it is a
+ * tail view) and prefixing "…" when clipped. Walks code points so wide CJK
+ * chars count as 2 columns and surrogate pairs are never split.
+ */
+export function clipTail(text: string, budget: number): string {
+	if (!text || budget <= 0) return "";
+	if (visibleWidth(text) <= budget) return text;
+	if (budget === 1) return "…";
+	const limit = budget - 1; // reserve one column for the ellipsis
+	let w = 0;
+	const codePoints = Array.from(text);
+	let i = codePoints.length;
+	while (i > 0) {
+		const start = i - 1;
+		const codePoint = codePoints[start] ?? "";
+		const cw = visibleWidth(codePoint);
+		if (w + cw > limit) break;
+		w += cw;
+		i = start;
+	}
+	return "…" + codePoints.slice(i).join("");
+}
+
+/**
+ * Build the label Pi renders in its hidden-thinking block. `width` is a
+ * conservative budget that keeps each native Text row within the terminal.
+ * In two-line mode, an overflowing latest logical line uses both rows for
+ * its continuation instead of retaining the previous logical line.
+ */
+export function buildPeekLabel(
+	state: PeekState,
+	frame: number,
+	glyphs: IconGlyphs,
+	width: number,
+	lineCount = 1,
+): string {
+	const w = Math.max(1, Math.floor(width));
+	const prefix = `${glyphs.thinking} think`;
+	const count = normalizePeekLineCount(lineCount);
+	const fit = (line: string): string => truncateToWidth(line, w, "…");
+	switch (state.phase) {
+		case "thinking": {
+			const spin = SPINNER_FRAMES[frame % SPINNER_FRAMES.length] ?? "";
+			// Thinking text is model output (untrusted): strip terminal control
+			// sequences before placing it in Pi's native label.
+			const marker = `${prefix} ${spin}`;
+			const markerWidth = visibleWidth(`${marker} `);
+			const contentWidth = Math.max(0, w - markerWidth);
+			const thoughtIndent = " ".repeat(markerWidth);
+			const safeLines = state.tail
+				.split("\n")
+				.map((tail) => sanitizeStatus(tail))
+				.filter(Boolean)
+				.slice(-count);
+			const latest = safeLines.at(-1) ?? "";
+			const lineWithMarker = (tail: string): string => fit(tail ? `${marker} ${tail}` : marker);
+			if (count >= 2) {
+				const latestWrapped = wrapTextWithAnsi(latest, Math.max(1, contentWidth));
+				if (latestWrapped.length > 1) {
+					// Spend both rows on an overflowing latest thought; stale context must
+					// not displace its continuation.
+					const first = latestWrapped[0] ?? "";
+					const second = latestWrapped[1] ?? "";
+					return `${lineWithMarker(first)}\n${fit(`${thoughtIndent}${second}`)}`;
+				}
+			}
+			const firstTail = clipTail(count >= 2 ? safeLines[0] ?? "" : latest, contentWidth);
+			if (count < 2 || safeLines.length < 2) return lineWithMarker(firstTail);
+			// Align the latest line with the first line's thinking text, not with
+			// the status marker.
+			const secondTail = clipTail(latest, contentWidth);
+			return `${lineWithMarker(firstTail)}\n${fit(secondTail ? `${thoughtIndent}${secondTail}` : thoughtIndent)}`;
+		}
+		case "done":
+			return fit(`${prefix} ${glyphs.done}`);
+		default:
+			return fit(`${prefix} ·`);
+	}
+}

--- a/extensions/open-tui/settings-command.ts
+++ b/extensions/open-tui/settings-command.ts
@@ -9,7 +9,7 @@ import {
 	type TUI,
 	Text,
 } from "@earendil-works/pi-tui";
-import type { CursorStyle, IconMode, OpenTuiConfig, SettingsLanguage } from "./config.ts";
+import type { CursorStyle, IconMode, OpenTuiConfig, SettingsLanguage, ThinkingPeekLines } from "./config.ts";
 import {
 	DEFAULT_FULLSCREEN_WHEEL_SCROLL_LINES,
 	normalizeFullscreenWheelScrollLines,
@@ -32,6 +32,7 @@ const COPY = {
 		hint: "Tab/Shift+Tab/←/→: tabs · ↑/↓: move · Enter/Space: change · Enter on wheel speed: type 1-10 · Esc/q: close",
 		labels: {
 			enabled: "Enabled",
+			thinkingPeek: "Thinking peek",
 			language: "Language",
 			wheelScrollLines: "Mouse wheel speed",
 			cursorStyle: "Cursor style",
@@ -54,6 +55,7 @@ const COPY = {
 		values: {
 			on: "On",
 			off: "Off",
+			thinkingPeek: { off: "Off", one: "1 line", two: "2 lines" },
 			languages: { en: "English", zh: "简体中文" },
 			wheelLines: (count: number) => `${count} ${count === 1 ? "line" : "lines"} / notch`,
 			wheelPrompt: (count: number) => `Wheel scroll lines per notch, 1-10 (current: ${count}). Enter: apply · Esc: cancel`,
@@ -67,6 +69,7 @@ const COPY = {
 		hint: "Tab/Shift+Tab/←/→：切页 · ↑/↓：移动 · Enter/Space：更改 · 滚轮速度项 Enter 输入 1-10 · Esc/q：关闭",
 		labels: {
 			enabled: "启用",
+			thinkingPeek: "思考预览",
 			language: "语言",
 			wheelScrollLines: "鼠标滚轮速度",
 			cursorStyle: "光标样式",
@@ -89,6 +92,7 @@ const COPY = {
 		values: {
 			on: "开启",
 			off: "关闭",
+			thinkingPeek: { off: "关闭", one: "单行", two: "双行" },
 			languages: { en: "English", zh: "简体中文" },
 			wheelLines: (count: number) => `每格 ${count} 行`,
 			wheelPrompt: (count: number) => `滚轮每格滚动行数（当前 ${count}，范围 1-10），输入后 Enter 应用 · Esc 取消`,
@@ -99,6 +103,11 @@ const COPY = {
 } as const;
 
 type SettingsCopy = (typeof COPY)[SettingsLanguage];
+
+function formatThinkingPeekLines(lines: ThinkingPeekLines, copy: SettingsCopy): string {
+	const values = [copy.values.thinkingPeek.off, copy.values.thinkingPeek.one, copy.values.thinkingPeek.two];
+	return values[lines] ?? values[0];
+}
 
 function toggleSetting(config: OpenTuiConfig, key: keyof OpenTuiConfig["footerSegments"]): OpenTuiConfig {
 	return {
@@ -152,15 +161,25 @@ function toggleTelemetry(config: OpenTuiConfig, key: keyof OpenTuiConfig["teleme
 	};
 }
 
+function cycleThinkingPeek(config: OpenTuiConfig): OpenTuiConfig {
+	const next = ([1, 2, 0] as const)[config.thinkingPeek.lines] ?? 0;
+	return {
+		...config,
+		thinkingPeek: { lines: next },
+	};
+}
+
 function buildFeaturesItems(config: OpenTuiConfig, copy: SettingsCopy): SettingItem[] {
+	const flag = (value: boolean) => value ? copy.values.on : copy.values.off;
 	return [
-		{ id: "enabled", label: copy.labels.enabled, currentValue: config.enabled ? copy.values.on : copy.values.off },
+		{ id: "enabled", label: copy.labels.enabled, currentValue: flag(config.enabled) },
 		{ id: "settingsLanguage", label: copy.labels.language, currentValue: copy.values.languages[config.settingsLanguage] },
 		{
 			id: "wheelScrollLines",
 			label: copy.labels.wheelScrollLines,
 			currentValue: copy.values.wheelLines(config.fullscreen.wheelScrollLines),
 		},
+		{ id: "thinkingPeek", label: copy.labels.thinkingPeek, currentValue: formatThinkingPeekLines(config.thinkingPeek.lines, copy) },
 	];
 }
 
@@ -220,6 +239,7 @@ function handleSettingChange(
 	if (tab === "features") {
 		if (itemId === "enabled") return toggleEnabled(config);
 		if (itemId === "settingsLanguage") return toggleLanguage(config);
+		if (itemId === "thinkingPeek") return cycleThinkingPeek(config);
 	}
 	if (tab === "icons") {
 		if (itemId === "mode") return cycleIconMode(config);

--- a/extensions/open-tui/settings-command.ts
+++ b/extensions/open-tui/settings-command.ts
@@ -5,6 +5,7 @@ import {
 	Key,
 	matchesKey,
 	SelectList,
+	type Component,
 	type SelectItem,
 	type TUI,
 	Text,
@@ -260,6 +261,23 @@ interface SettingsUiHandle {
 	handleInput: (data: string) => void;
 }
 
+function insertComponentAfter(list: Component, child: Component, index: () => number): Component {
+	// SelectList renders one line per item; splice the editor into that output.
+	return {
+		render(width: number): string[] {
+			const lines = list.render(width);
+			const insertAt = index();
+			if (insertAt < 0 || insertAt >= lines.length) return lines;
+			const childLines = child.render(width);
+			return [...lines.slice(0, insertAt + 1), ...childLines, ...lines.slice(insertAt + 1)];
+		},
+		invalidate(): void {
+			list.invalidate();
+			child.invalidate();
+		},
+	};
+}
+
 class SettingsUi implements SettingsUiHandle {
 	private tab: Tab = "features";
 	private config: OpenTuiConfig;
@@ -377,7 +395,6 @@ class SettingsUi implements SettingsUiHandle {
 		this.selectList.onCancel = () => {
 			this.onClose();
 		};
-		this.container.addChild(this.selectList);
 		if (editingWheel) {
 			this.wheelInput!.focused = true;
 			const wheelInputGroup = new Box(4, 0);
@@ -387,7 +404,10 @@ class SettingsUi implements SettingsUiHandle {
 				0,
 			));
 			wheelInputGroup.addChild(this.wheelInput!);
-			this.container.addChild(wheelInputGroup);
+			const selectedIndex = () => items.findIndex((item) => item.value === this.selectList.getSelectedItem()?.value);
+			this.container.addChild(insertComponentAfter(this.selectList, wheelInputGroup, selectedIndex));
+		} else {
+			this.container.addChild(this.selectList);
 		}
 
 		this.cachedWidth = undefined;

--- a/extensions/open-tui/utils.ts
+++ b/extensions/open-tui/utils.ts
@@ -1,15 +1,22 @@
 import { isAbsolute, relative, resolve, sep } from "node:path";
 import type { ThinkingLevel } from "@earendil-works/pi-ai";
 import type { Theme, ThemeColor } from "@earendil-works/pi-coding-agent";
-import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import {
+	stripTerminalSequences as stripTerminalSequencesFromTui,
+	truncateToWidth,
+	visibleWidth,
+} from "@earendil-works/pi-tui";
 
 export { truncateToWidth, visibleWidth };
 
+// pi-tui handles the common ANSI/OSC/APC forms. Keep a generic CSI pass for
+// valid sequences whose final byte is outside its intentionally narrow set.
+const CSI_SEQUENCE = /(?:\x1b\[|\x9b)[0-?]*[ -/]*[@-~]/g;
+
 export function stripAnsi(text: string): string {
-	return text
-		.replace(/\x1b\[[0-9;]*m/g, "")
-		.replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, "")
-		.replace(/\x1b_[^\x07]*\x07/g, "");
+	// Remove CSI first so pi-tui's parser cannot mistake an unsupported CSI
+	// final byte for part of a later sequence and swallow intervening text.
+	return stripTerminalSequencesFromTui(text.replace(CSI_SEQUENCE, ""));
 }
 
 export function formatCwd(cwd: string): string {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "test": "node --test tests/settings-command.test.ts tests/fullscreen-scroll.test.ts tests/footer.test.ts tests/editor.test.ts tests/telemetry.test.ts",
+    "test": "node --test tests/settings-command.test.ts tests/fullscreen-scroll.test.ts tests/footer.test.ts tests/editor.test.ts tests/telemetry.test.ts tests/peek.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "pi": {

--- a/tests/peek.test.ts
+++ b/tests/peek.test.ts
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import {
+	buildPeekLabel,
+	clipTail,
+	collectPeekParts,
+	createPeekState,
+	peekTail,
+	reducePeek,
+} from "../extensions/open-tui/peek.ts";
+import type { IconGlyphs } from "../extensions/open-tui/icons.ts";
+import { sanitizeStatus } from "../extensions/open-tui/utils.ts";
+
+const glyphs = { thinking: "~", done: "+" } as IconGlyphs;
+
+test("collectPeekParts joins thinking and answer text, ignoring other parts", () => {
+	const parts = collectPeekParts([
+		{ type: "thinking", thinking: "alpha" },
+		{ type: "text", text: "answer" },
+		{ type: "toolCall", id: "x", name: "read", arguments: {} },
+		{ type: "thinking", thinking: " beta" },
+	]);
+	assert.deepEqual(parts, { thinking: "alpha beta", text: "answer" });
+});
+
+test("collectPeekParts tolerates non-array content", () => {
+	assert.deepEqual(collectPeekParts(undefined), { thinking: "", text: "" });
+	assert.deepEqual(collectPeekParts("nope"), { thinking: "", text: "" });
+});
+
+test("collectPeekParts ignores non-string fields without coercing or throwing", () => {
+	assert.deepEqual(
+		collectPeekParts([
+			{ type: "thinking", thinking: Symbol("invalid"), text: "fallback" },
+			{ type: "thinking", thinking: { invalid: true }, text: " next" },
+			{ type: "text", text: { invalid: true } },
+			{ type: "text", text: Symbol("invalid") },
+		]),
+		{ thinking: "fallback next", text: "" },
+	);
+});
+
+test("peekTail shows the last logical line only", () => {
+	assert.equal(peekTail("first line\nsecond line here"), "second line here");
+});
+
+test("peekTail keeps the last two logical lines when requested", () => {
+	assert.equal(peekTail("first\nsecond\n\nthird", 2), "second\nthird");
+});
+
+test("peekTail trims and collapses whitespace", () => {
+	assert.equal(peekTail("  padded   text  \n"), "padded text");
+	assert.equal(peekTail("   "), "");
+	assert.equal(peekTail(""), "");
+});
+
+test("peekTail keeps the full tail; width bounding is clipTail's job", () => {
+	assert.equal(peekTail("x".repeat(500)).length, 500);
+});
+
+test("clipTail keeps the end of long text within budget", () => {
+	const tail = clipTail("x".repeat(500), 10);
+	assert.equal(tail, "…" + "x".repeat(9));
+});
+
+test("clipTail truncates wide CJK text by visible width, not code points", () => {
+	const tail = clipTail("思".repeat(100), 10);
+	// budget 10 → 1 col for "…" + 4 wide chars (8 cols) = 9 visible columns
+	assert.equal(tail, "…" + "思".repeat(4));
+	assert.ok(visibleWidth(tail) <= 10);
+});
+
+test("clipTail returns text that already fits untouched", () => {
+	assert.equal(clipTail("short", 10), "short");
+	assert.equal(clipTail("思思", 4), "思思");
+});
+
+test("clipTail handles degenerate budgets", () => {
+	assert.equal(clipTail("abc", 0), "");
+	assert.equal(clipTail("abc", -5), "");
+	assert.equal(clipTail("", 5), "");
+	assert.equal(clipTail("abcdef", 1), "…");
+});
+
+test("clipTail never splits a surrogate pair", () => {
+	const tail = clipTail("😀".repeat(50), 5);
+	assert.ok(tail.startsWith("…"));
+	assert.ok(!tail.includes("�"));
+	assert.ok(visibleWidth(tail) <= 5);
+});
+
+test("buildPeekLabel renders each phase", () => {
+	const state = createPeekState();
+	assert.equal(buildPeekLabel(state, 0, glyphs, 80), "~ think ·");
+
+	state.phase = "thinking";
+	state.tail = "deriving";
+	assert.equal(buildPeekLabel(state, 1, glyphs, 80), "~ think ⠙ deriving");
+
+	state.phase = "done";
+	assert.equal(buildPeekLabel(state, 2, glyphs, 80), "~ think +");
+});
+
+test("buildPeekLabel aligns the latest thought with the previous thought", () => {
+	const label = buildPeekLabel(
+		{ phase: "thinking", tail: "previous thought\nlatest thought" },
+		0,
+		glyphs,
+		80,
+		2,
+	);
+	const [previous, latest] = label.split("\n");
+	assert.ok(previous !== undefined && latest !== undefined);
+	assert.equal(previous.indexOf("previous thought"), latest.indexOf("latest thought"));
+});
+
+test("buildPeekLabel wraps an overflowing latest thought instead of keeping the previous one", () => {
+	const label = buildPeekLabel(
+		{ phase: "thinking", tail: "previous thought\nabcdefghijklmnopqrstuvwxyz" },
+		0,
+		glyphs,
+		30,
+		2,
+	);
+	const [first, second] = label.split("\n");
+	assert.ok(first !== undefined && second !== undefined);
+	assert.ok(!label.includes("previous thought"));
+	assert.match(first, /~ think ⠋ abcdefghijklmnopqrst/);
+	assert.match(second, /uvwxyz$/);
+	assert.equal(first.indexOf("abcdefghijklmnopqrst"), second.indexOf("uvwxyz"));
+});
+
+test("buildPeekLabel never exceeds the label width, even on narrow terminals", () => {
+	const state = { phase: "thinking" as const, tail: "思".repeat(200) };
+	for (const width of [80, 40, 8, 200]) {
+		assert.ok(visibleWidth(buildPeekLabel(state, 0, glyphs, width)) <= width);
+	}
+	for (const line of buildPeekLabel({ phase: "thinking", tail: "前一行\n最新一行" }, 0, glyphs, 40, 2).split("\n")) {
+		assert.ok(visibleWidth(line) <= 40);
+	}
+});
+
+test("buildPeekLabel fills wide terminals instead of a fixed cap", () => {
+	const state = { phase: "thinking" as const, tail: "x".repeat(500) };
+	const line = buildPeekLabel(state, 0, glyphs, 200);
+	assert.ok(visibleWidth(line) > 92, "wide terminals must see more than the old 92-col cap");
+});
+
+test("reducePeek: spinner starts on thinking, stops when answer text arrives", () => {
+	const idle = createPeekState();
+	const t = reducePeek(idle, { thinking: "reasoning", text: "" });
+	assert.equal(t.phase, "thinking");
+	assert.equal(t.tail, "reasoning");
+
+	const done = reducePeek(t, { thinking: "reasoning more", text: "answer" });
+	assert.equal(done.phase, "done");
+
+	// Cumulative thinking keeps arriving after the answer starts: stay done.
+	const after = reducePeek(done, { thinking: "reasoning more", text: "answer more" });
+	assert.equal(after.phase, "done");
+	assert.equal(after.tail, "reasoning more");
+});
+
+test("reducePeek keeps two thinking lines for the double-line label", () => {
+	const next = reducePeek(createPeekState(), { thinking: "previous\nlatest", text: "" });
+	assert.equal(next.phase, "thinking");
+	assert.equal(next.tail, "previous\nlatest");
+});
+
+test("reducePeek: a mixed thinking+text first update never spins", () => {
+	const next = reducePeek(createPeekState(), { thinking: "short", text: "hi" });
+	assert.equal(next.phase, "done");
+});
+
+test("reducePeek: text-only updates stay idle", () => {
+	const next = reducePeek(createPeekState(), { thinking: "", text: "plain answer" });
+	assert.equal(next.phase, "idle");
+});
+
+test("buildPeekLabel neutralizes terminal control sequences in thinking text", () => {
+	const dirty = "\x1b]0;pwned\x07\x1b[31mred\x1b[0m\x1b[2J\x1b[?25l tail";
+	const line = buildPeekLabel({ phase: "thinking", tail: dirty }, 0, glyphs, 80);
+	assert.equal(line, "~ think ⠋ red tail");
+	assert.ok(!line.includes("\x1b[31m"), "injected SGR must be removed");
+	assert.ok(!line.includes("\x1b]"), "injected OSC must be removed");
+	assert.ok(!line.includes("\x1b"), "no raw control sequences may remain");
+});
+
+test("sanitizeStatus preserves text around unsupported CSI sequences", () => {
+	assert.equal(sanitizeStatus("\x1b[?25lvisible\x1b[31m text"), "visible text");
+});

--- a/tests/settings-command.test.ts
+++ b/tests/settings-command.test.ts
@@ -339,17 +339,41 @@ test("keeps localized settings and values within narrow widths", async () => {
 	}
 });
 
-test("falls back to English for an invalid settings language", () => {
+test("normalizes invalid settings values", () => {
 	const agentDir = mkdtempSync(join(tmpdir(), "pi-open-tui-"));
 	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
 	try {
 		process.env.PI_CODING_AGENT_DIR = agentDir;
-		writeFileSync(join(agentDir, "open-tui.json"), JSON.stringify({ settingsLanguage: "de", cursorStyle: "invalid" }), "utf8");
-		assert.equal(loadConfig().settingsLanguage, "en");
-		assert.equal(loadConfig().cursorStyle, "block");
+		writeFileSync(join(agentDir, "open-tui.json"), JSON.stringify({
+			settingsLanguage: "de",
+			cursorStyle: "invalid",
+			thinkingPeek: { lines: 9 },
+		}), "utf8");
+		const loaded = loadConfig();
+		assert.equal(loaded.settingsLanguage, "en");
+		assert.equal(loaded.cursorStyle, "block");
+		assert.equal(loaded.thinkingPeek.lines, 1);
 	} finally {
 		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
 		rmSync(agentDir, { recursive: true, force: true });
 	}
+});
+
+test("cycles the thinking peek line count from General settings", async () => {
+	const config = structuredClone(DEFAULT_CONFIG);
+	const settings = await openSettings(config);
+	// Enabled → Language → Wheel speed → Thinking peek
+	settings.component.handleInput("\x1b[B");
+	settings.component.handleInput("\x1b[B");
+	settings.component.handleInput("\x1b[B");
+	assert.match(selectedLine(settings.component), /Thinking peek/);
+	assert.match(selectedLine(settings.component), /1 line/);
+	settings.component.handleInput("\r");
+	assert.equal(settings.getConfig().thinkingPeek.lines, 2);
+	settings.component.handleInput("\r");
+	assert.equal(settings.getConfig().thinkingPeek.lines, 0);
+	settings.component.handleInput("\r");
+	assert.equal(settings.getConfig().thinkingPeek.lines, 1);
+	settings.component.handleInput("q");
 });

--- a/tests/settings-command.test.ts
+++ b/tests/settings-command.test.ts
@@ -130,12 +130,15 @@ test("updates fullscreen mouse wheel speed by typing a number", async () => {
 	// Enter opens the number input, type 8, Enter applies.
 	settings.component.handleInput("\r");
 	const editingLines = settings.component.render(80);
-	const parentLine = editingLines.find((line) => line.includes("→ Mouse wheel speed"));
-	const promptLine = editingLines.find((line) => line.includes("Wheel scroll lines per notch"));
+	const parentIndex = editingLines.findIndex((line) => line.includes("→ Mouse wheel speed"));
+	const promptIndex = editingLines.findIndex((line) => line.includes("Wheel scroll lines per notch"));
+	const parentLine = editingLines[parentIndex];
+	const promptLine = editingLines[promptIndex];
 	const inputLine = editingLines.find((line) => line.includes("> "));
 	assert.ok(parentLine);
 	assert.ok(promptLine);
 	assert.ok(inputLine);
+	assert.equal(promptIndex, parentIndex + 1);
 	const parentLabelStart = parentLine.indexOf("Mouse wheel speed");
 	const promptStart = promptLine.indexOf("Wheel scroll lines per notch");
 	const inputStart = inputLine.indexOf("> ");

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import type {
@@ -440,4 +443,73 @@ test("open-tui notifies once after a complete agent run", () => {
 	emit("agent_settled", { type: "agent_settled" });
 	assert.equal(notifications.length, 1);
 	assert.match(notifications[0]!, /TPS .*TTFT/);
+});
+
+test("open-tui keeps a prior peek label while a custom task is starting", async () => {
+	const handlers = new Map<string, Array<(event: any, ctx: ExtensionContext) => void | Promise<void>>>();
+	const labels: Array<string | undefined> = [];
+	const pi = {
+		on(event: string, handler: (event: any, ctx: ExtensionContext) => void | Promise<void>) {
+			handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+		},
+		registerCommand() {},
+		getThinkingLevel: () => "high",
+	} as unknown as ExtensionAPI;
+	const ctx = {
+		hasUI: true,
+		mode: "tui",
+		cwd: process.cwd(),
+		ui: {
+			theme,
+			notify() {},
+			setHeader() {},
+			setFooter() {},
+			setEditorComponent() {},
+			setHiddenThinkingLabel(label?: string) {
+				labels.push(label);
+			},
+		},
+	} as unknown as ExtensionContext;
+	const emit = async (event: string, payload: unknown) => {
+		await Promise.all((handlers.get(event) ?? []).map((handler) => handler(payload, ctx)));
+	};
+	const assistant = {
+		role: "assistant",
+		content: [{ type: "thinking", thinking: "previous task" }],
+	};
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const agentDir = await mkdtemp(join(tmpdir(), "open-tui-peek-"));
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+
+	try {
+		openTui(pi);
+		await emit("session_start", { type: "session_start" });
+		await emit("agent_start", { type: "agent_start" });
+		await emit("turn_start", { type: "turn_start" });
+		await emit("message_start", { type: "message_start", message: assistant });
+		await emit("message_update", {
+			type: "message_update",
+			message: assistant,
+			assistantMessageEvent: { type: "thinking_delta", delta: "previous task" },
+		});
+		const previousLabel = labels.at(-1);
+
+		await emit("agent_settled", { type: "agent_settled" });
+		// A custom/continuation task can spend time preparing before its assistant
+		// message_start. Its start must still invalidate the previous settle timer.
+		await emit("agent_start", { type: "agent_start" });
+		const labelsAfterNewTaskStart = labels.length;
+		await new Promise((resolve) => setTimeout(resolve, 350));
+
+		assert.ok(previousLabel);
+		assert.ok(
+			labels.slice(labelsAfterNewTaskStart).every((label) => label !== undefined),
+			"a stale settle timer must not clear the new task's label",
+		);
+	} finally {
+		await emit("session_shutdown", { type: "session_shutdown" });
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		await rm(agentDir, { recursive: true, force: true });
+	}
 });


### PR DESCRIPTION

   Show a compact one-line ticker above the editor while a task runs:
   - streams the tail of the model's live reasoning with a spinner;
   - settles on a check mark when the answer starts;
   - disappears after the task settles.

   Width-bounded by visible width so CJK-wide thinking text cannot overflow the terminal. Toggle via /open-tui (General
 -> Thinking peek) or thinkingPeek.enabled in open-tui.json.

   ## Summary

   Adds a middle ground between "fully expanded" and "fully hidden" reasoning output. When the model thinks, a single
 line above the editor shows where the reasoning currently is — the tail of the live thinking text streams beside a
 spinner, giving the speed feel of the wait without flooding the transcript. The line disappears once the task settles,
 and re-appears per task.

   Terminal-safety note: the line is capped at 92 columns and truncated by *visible width* (CJK/full-width chars count
 as 2 columns), because earlier experiments showed an overflowing line can crash pi's TUI when reasoning contains wide
 characters.

   Implementation overview:
   - `peek.ts` (new): pure helpers to collect thinking/answer parts from `message_update` content, bound the tail by
 visible width, and render the three phases (idle / thinking / done).
   - Widget lifecycle wired in `index.ts`: register on the first user message of a task, stream on `message_update`,
 freeze to `✓` when the answer starts (and between tool rounds), remove ~300ms after `agent_settled`. Includes an
 idle/replay guard so session restore never shows a stale line.
   - `thinkingPeek.enabled` config (default `true`, deep-merged for existing config files) with a toggle in `/open-tui`
 under **General → Thinking peek** (en/zh).

   ## Related issue

   None — new feature, no tracked issue.

   ## Validation

   - `npm test` — 54/54 pass (8 new: `tests/peek.test.ts` + a settings-toggle case in `tests/settings-command.test.ts`)
   - `npm run typecheck` — clean, 0 errors
   - Manual interactive check in pi (DeepSeek reasoning model):
     - ticker streams Chinese/English thinking tail live;
     - CJK-wide text truncates safely (no terminal overflow / crash);
     - answer start and multi-round tool calls show `✓` between reasoning bursts;
     - line disappears after the task settles.

   ## Checklist

   - [x] This PR contains one cohesive change; unrelated work is split into separate PRs.
   - [x] I have added or updated tests where the change requires them.
   - [x] I have run the relevant tests and checks.
   - [x] I have updated documentation where needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a live “Thinking peek” above the editor during task runs.
  - Shows recent reasoning text with a spinner and completion indicator.
  - Supports disabled, one-line, and two-line display modes.
  - Handles width-aware truncation, multiline wrapping, CJK text, and non-reasoning models.
  - Automatically hides after tasks finish.
  - Added configuration through General settings or `thinkingPeek.lines`; enabled with one line by default.

- **Documentation**
  - Documented the feature and configuration options in English and Chinese README files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->