### PR TITLE
fix: embed working status in editor border

### DIFF
--- a/extensions/open-tui/editor.ts
+++ b/extensions/open-tui/editor.ts
@@ -25,6 +25,11 @@ const CURSOR_STYLE_SEQUENCES: Partial<Record<CursorStyle, string>> = {
 };
 const DEFAULT_CURSOR_STYLE_SEQUENCE = "\x1b[0 q";
 
+interface WorkingStatusIndicator {
+	renderInBorder(width: number): string;
+	renderSpinnerInBorder(width: number): string;
+}
+
 interface HiddenThinkingLabelComponent {
 	children: unknown[];
 	setHiddenThinkingLabel(label: string): void;
@@ -78,9 +83,24 @@ function roundedBorder(
 	kind: "top" | "bottom",
 	paint: (s: string) => string,
 	sourceLine?: string,
+	status?: string,
 ): string {
 	if (width < 2) return paint(truncateToWidth(kind === "top" ? "╭╮" : "╰╯", width, ""));
 	const corners = kind === "top" ? (["╭", "╮"] as const) : (["╰", "╯"] as const);
+
+	if (kind === "top" && status) {
+		const plain = sourceLine ? stripAnsi(sourceLine) : "";
+		const scrollMatch = plain.match(/([↑↓]\s+\d+\s+more)/);
+		const left = paint("── ");
+		if (scrollMatch) {
+			const label = ` ${scrollMatch[1]} `;
+			const available = Math.max(0, width - 2 - visibleWidth(left) - visibleWidth(status) - visibleWidth(label));
+			const before = Math.floor(available / 2);
+			return `${corners[0]}${left}${status}${paint(` ${"─".repeat(before)}${label}${"─".repeat(available - before)}`)}${corners[1]}`;
+		}
+		const fill = Math.max(0, width - 2 - visibleWidth(left) - visibleWidth(status) - 1);
+		return `${corners[0]}${left}${status}${paint(` ${"─".repeat(fill)}`)}${corners[1]}`;
+	}
 
 	if (sourceLine) {
 		const plain = stripAnsi(sourceLine);
@@ -96,8 +116,10 @@ function roundedBorder(
 }
 
 export class OpenTuiEditor extends CustomEditor {
+	readonly embedWorkingStatus = true;
 	private readonly getRail: () => string;
 	private readonly getBorder: (s: string) => string;
+	private embeddedWorkingStatusIndicator: WorkingStatusIndicator | undefined;
 	private cursorStyle: CursorStyle;
 	private previewHardwareCursor = false;
 
@@ -122,6 +144,43 @@ export class OpenTuiEditor extends CustomEditor {
 		super.setPaddingX(0);
 	}
 
+	setWorkingStatusIndicator(indicator: WorkingStatusIndicator | undefined): void {
+		this.embeddedWorkingStatusIndicator = indicator;
+		this.tui.requestRender();
+	}
+
+	protected renderTopBorder(width: number, hiddenLineCount: number): string {
+		const indicator = this.embeddedWorkingStatusIndicator;
+		if (!indicator || width <= 0) {
+			return this.getBorder(hiddenLineCount > 0 ? `↑ ${hiddenLineCount} more` : "─".repeat(width));
+		}
+
+		let status = indicator.renderInBorder(Math.max(1, width - 5));
+		let statusWidth = visibleWidth(status);
+		if (statusWidth === 0) return this.getBorder("─".repeat(width));
+
+		const overflowLabel = hiddenLineCount > 0 ? ` ↑ ${hiddenLineCount} more ` : undefined;
+		const overflowLabelWidth = overflowLabel ? visibleWidth(overflowLabel) : 0;
+		const overflowStart = Math.floor((width - overflowLabelWidth) / 2);
+		const canFitOverflow = () => overflowLabel !== undefined
+			&& overflowLabelWidth + 2 <= width
+			&& overflowStart - (3 + statusWidth + 1) >= 1;
+		if (overflowLabel && !canFitOverflow()) {
+			status = indicator.renderSpinnerInBorder(width);
+			statusWidth = visibleWidth(status);
+		}
+		if (canFitOverflow()) {
+			const leftBlockWidth = 3 + statusWidth + 1;
+			return this.getBorder("── ") + status + this.getBorder(` ${"─".repeat(overflowStart - leftBlockWidth)}${overflowLabel}${"─".repeat(width - overflowStart - overflowLabelWidth)}`);
+		}
+		if (width >= statusWidth + 5) {
+			return this.getBorder("── ") + status + this.getBorder(` ${"─".repeat(width - statusWidth - 4)}`);
+		}
+		status = indicator.renderSpinnerInBorder(width);
+		statusWidth = visibleWidth(status);
+		const prefixWidth = Math.min(3, Math.max(0, width - statusWidth));
+		return this.getBorder("─".repeat(prefixWidth)) + status + this.getBorder("─".repeat(Math.max(0, width - prefixWidth - statusWidth)));
+	}
 	setCursorStyle(cursorStyle: CursorStyle, blockHardwareCursor = false): void {
 		const styleChanged = cursorStyle !== this.cursorStyle;
 		this.previewHardwareCursor = cursorStyle !== "block";
@@ -162,8 +221,9 @@ export class OpenTuiEditor extends CustomEditor {
 		const baseLines = this.renderBase(innerWidth);
 		const bottomIdx = findBottomBorderIndex(baseLines);
 
+		const status = this.embeddedWorkingStatusIndicator?.renderInBorder(Math.max(1, innerWidth - 5)) ?? "";
 		const result: string[] = [];
-		result.push(roundedBorder(width, "top", borderPaint, baseLines[0]));
+		result.push(roundedBorder(width, "top", borderPaint, baseLines[0], status));
 
 		for (let i = 1; i < bottomIdx; i++) {
 			const line = baseLines[i] ?? "";

--- a/extensions/open-tui/editor.ts
+++ b/extensions/open-tui/editor.ts
@@ -83,23 +83,40 @@ function roundedBorder(
 	kind: "top" | "bottom",
 	paint: (s: string) => string,
 	sourceLine?: string,
-	status?: string,
+	indicator?: WorkingStatusIndicator,
 ): string {
 	if (width < 2) return paint(truncateToWidth(kind === "top" ? "╭╮" : "╰╯", width, ""));
 	const corners = kind === "top" ? (["╭", "╮"] as const) : (["╰", "╯"] as const);
 
-	if (kind === "top" && status) {
+	if (kind === "top" && indicator) {
 		const plain = sourceLine ? stripAnsi(sourceLine) : "";
 		const scrollMatch = plain.match(/([↑↓]\s+\d+\s+more)/);
-		const left = paint("── ");
-		if (scrollMatch) {
-			const label = ` ${scrollMatch[1]} `;
-			const available = Math.max(0, width - 2 - visibleWidth(left) - visibleWidth(status) - visibleWidth(label));
-			const before = Math.floor(available / 2);
-			return `${corners[0]}${left}${status}${paint(` ${"─".repeat(before)}${label}${"─".repeat(available - before)}`)}${corners[1]}`;
+		const contentWidth = width - 2;
+		let status = indicator.renderInBorder(Math.max(1, contentWidth - 5));
+		let statusWidth = visibleWidth(status);
+		if (statusWidth > 0) {
+			const overflowLabel = scrollMatch ? ` ${scrollMatch[1]} ` : undefined;
+			const overflowLabelWidth = overflowLabel ? visibleWidth(overflowLabel) : 0;
+			const overflowStart = Math.floor((contentWidth - overflowLabelWidth) / 2);
+			const canFitOverflow = () => overflowLabel !== undefined
+				&& overflowLabelWidth + 2 <= contentWidth
+				&& overflowStart - (3 + statusWidth + 1) >= 1;
+			if (overflowLabel && !canFitOverflow()) {
+				status = indicator.renderSpinnerInBorder(contentWidth);
+				statusWidth = visibleWidth(status);
+			}
+			if (canFitOverflow()) {
+				const leftBlockWidth = 3 + statusWidth + 1;
+				return `${corners[0]}${paint("── ")}${status}${paint(` ${"─".repeat(overflowStart - leftBlockWidth)}${overflowLabel}${"─".repeat(contentWidth - overflowStart - overflowLabelWidth)}`)}${corners[1]}`;
+			}
+			if (contentWidth >= statusWidth + 5) {
+				return `${corners[0]}${paint("── ")}${status}${paint(` ${"─".repeat(contentWidth - statusWidth - 4)}`)}${corners[1]}`;
+			}
+			status = indicator.renderSpinnerInBorder(contentWidth);
+			statusWidth = visibleWidth(status);
+			const prefixWidth = Math.min(3, Math.max(0, contentWidth - statusWidth));
+			return `${corners[0]}${paint("─".repeat(prefixWidth))}${status}${paint("─".repeat(Math.max(0, contentWidth - prefixWidth - statusWidth)))}${corners[1]}`;
 		}
-		const fill = Math.max(0, width - 2 - visibleWidth(left) - visibleWidth(status) - 1);
-		return `${corners[0]}${left}${status}${paint(` ${"─".repeat(fill)}`)}${corners[1]}`;
 	}
 
 	if (sourceLine) {
@@ -149,38 +166,6 @@ export class OpenTuiEditor extends CustomEditor {
 		this.tui.requestRender();
 	}
 
-	protected renderTopBorder(width: number, hiddenLineCount: number): string {
-		const indicator = this.embeddedWorkingStatusIndicator;
-		if (!indicator || width <= 0) {
-			return this.getBorder(hiddenLineCount > 0 ? `↑ ${hiddenLineCount} more` : "─".repeat(width));
-		}
-
-		let status = indicator.renderInBorder(Math.max(1, width - 5));
-		let statusWidth = visibleWidth(status);
-		if (statusWidth === 0) return this.getBorder("─".repeat(width));
-
-		const overflowLabel = hiddenLineCount > 0 ? ` ↑ ${hiddenLineCount} more ` : undefined;
-		const overflowLabelWidth = overflowLabel ? visibleWidth(overflowLabel) : 0;
-		const overflowStart = Math.floor((width - overflowLabelWidth) / 2);
-		const canFitOverflow = () => overflowLabel !== undefined
-			&& overflowLabelWidth + 2 <= width
-			&& overflowStart - (3 + statusWidth + 1) >= 1;
-		if (overflowLabel && !canFitOverflow()) {
-			status = indicator.renderSpinnerInBorder(width);
-			statusWidth = visibleWidth(status);
-		}
-		if (canFitOverflow()) {
-			const leftBlockWidth = 3 + statusWidth + 1;
-			return this.getBorder("── ") + status + this.getBorder(` ${"─".repeat(overflowStart - leftBlockWidth)}${overflowLabel}${"─".repeat(width - overflowStart - overflowLabelWidth)}`);
-		}
-		if (width >= statusWidth + 5) {
-			return this.getBorder("── ") + status + this.getBorder(` ${"─".repeat(width - statusWidth - 4)}`);
-		}
-		status = indicator.renderSpinnerInBorder(width);
-		statusWidth = visibleWidth(status);
-		const prefixWidth = Math.min(3, Math.max(0, width - statusWidth));
-		return this.getBorder("─".repeat(prefixWidth)) + status + this.getBorder("─".repeat(Math.max(0, width - prefixWidth - statusWidth)));
-	}
 	setCursorStyle(cursorStyle: CursorStyle, blockHardwareCursor = false): void {
 		const styleChanged = cursorStyle !== this.cursorStyle;
 		this.previewHardwareCursor = cursorStyle !== "block";
@@ -221,9 +206,8 @@ export class OpenTuiEditor extends CustomEditor {
 		const baseLines = this.renderBase(innerWidth);
 		const bottomIdx = findBottomBorderIndex(baseLines);
 
-		const status = this.embeddedWorkingStatusIndicator?.renderInBorder(Math.max(1, innerWidth - 5)) ?? "";
 		const result: string[] = [];
-		result.push(roundedBorder(width, "top", borderPaint, baseLines[0], status));
+		result.push(roundedBorder(width, "top", borderPaint, baseLines[0], this.embeddedWorkingStatusIndicator));
 
 		for (let i = 1; i < bottomIdx; i++) {
 			const line = baseLines[i] ?? "";

--- a/extensions/open-tui/footer.ts
+++ b/extensions/open-tui/footer.ts
@@ -15,7 +15,6 @@ import {
 	formatCwd,
 	formatDuration,
 	formatInputBreakdown,
-	formatProviderLabel,
 	providerColor,
 	sanitizeStatus,
 	stressColor,

--- a/extensions/open-tui/state.ts
+++ b/extensions/open-tui/state.ts
@@ -3,7 +3,7 @@ import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { GitStatus } from "./git.ts";
 import { emptyGitStatus } from "./git.ts";
 import type { RuntimeInfo } from "./runtime.ts";
-import { finiteOrZero, fmtTokens, formatProviderLabel } from "./utils.ts";
+import { finiteOrZero, formatProviderLabel } from "./utils.ts";
 
 export interface FooterState {
 	git: GitStatus;

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -36,6 +36,21 @@ test("compensates Pi editor padding for the custom left rail", () => {
 	assert.equal(contentLine.indexOf("x"), 2);
 });
 
+test("embeds the working indicator in the editor top border", () => {
+	const editor = new OpenTuiEditor(
+		tui,
+		editorTheme,
+		{ matches: () => false } as unknown as KeybindingsManager,
+	);
+	editor.setWorkingStatusIndicator({
+		renderInBorder: () => "◐ working",
+		renderSpinnerInBorder: () => "◐",
+	});
+
+	assert.match(stripAnsi(editor.render(40)[0] ?? ""), /^╭── ◐ working ─+╮$/);
+});
+
+
 test("uses the terminal hardware cursor for non-block styles", () => {
 	for (const [cursorStyle, sequence] of [
 		["bar", "\x1b[6 q"],

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { KeybindingsManager } from "@earendil-works/pi-coding-agent";
-import { TuiMainScreen, type EditorTheme, type Terminal, type TUI } from "@earendil-works/pi-tui";
+import { TuiMainScreen, type EditorTheme, type Terminal, type TUI, visibleWidth } from "@earendil-works/pi-tui";
 import { installEditor, OpenTuiEditor } from "../extensions/open-tui/editor.ts";
 import { stripAnsi } from "../extensions/open-tui/utils.ts";
 
@@ -48,6 +48,30 @@ test("embeds the working indicator in the editor top border", () => {
 	});
 
 	assert.match(stripAnsi(editor.render(40)[0] ?? ""), /^╭── ◐ working ─+╮$/);
+});
+
+test("keeps a narrow scrolled working border intact", () => {
+	const editor = new OpenTuiEditor(
+		tui,
+		editorTheme,
+		{ matches: () => false } as unknown as KeybindingsManager,
+	);
+	editor.setText(Array.from({ length: 10 }, (_, index) => `line ${index}`).join("\n"));
+	let spinnerRenders = 0;
+	editor.setWorkingStatusIndicator({
+		renderInBorder: () => "◐ working status that ignores width",
+		renderSpinnerInBorder: () => {
+			spinnerRenders++;
+			return "◐";
+		},
+	});
+
+	const topBorder = stripAnsi(editor.render(30)[0] ?? "");
+
+	assert.equal(spinnerRenders, 1);
+	assert.equal(visibleWidth(topBorder), 30);
+	assert.match(topBorder, /↑ 3 more/);
+	assert.ok(topBorder.endsWith("╮"));
 });
 
 


### PR DESCRIPTION
## Summary
- Render the working status indicator in the editor top border.
- Preserve the centered overflow label and use the compact spinner when the border is narrow.
- Cover the embedded border indicator with an editor test.

## Validation
- `node --test tests/settings-command.test.ts tests/fullscreen-scroll.test.ts tests/footer.test.ts tests/editor.test.ts tests/telemetry.test.ts tests/peek.test.ts`
- `npm run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a working-status indicator to the editor’s top border.
  * Displays status text or a spinner alongside hidden-line information.

* **Tests**
  * Added coverage verifying that the working status appears correctly in the editor border.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->