### PR TITLE
fix: guard undefined lines in editor border scan (first-render TypeError)

### DIFF
--- a/extensions/open-tui/utils.ts
+++ b/extensions/open-tui/utils.ts
@@ -239,6 +239,7 @@ export function effortColor(level: ThinkingLevel | string | undefined): ThemeCol
 }
 
 export function isEditorBorderLine(line: string): boolean {
+	if (typeof line !== "string") return false;
 	const plain = stripAnsi(line);
 	if (/^─+$/.test(plain)) return true;
 	if (/^─*\s*[↑↓]\s+\d+\s+more\s*─*$/.test(plain)) return true;
@@ -247,7 +248,8 @@ export function isEditorBorderLine(line: string): boolean {
 
 export function findBottomBorderIndex(lines: string[]): number {
 	for (let i = lines.length - 1; i >= 1; i--) {
-		if (isEditorBorderLine(lines[i]!)) return i;
+		const line = lines[i];
+		if (line !== undefined && isEditorBorderLine(line)) return i;
 	}
 	return Math.max(0, lines.length - 1);
 }


### PR DESCRIPTION
## Crash

On pi-open-tui **0.3.3** (latest published at time of writing), every newly opened TUI pane crashed at first render:

```
TypeError ...
    at stripAnsi (extensions/open-tui/utils.ts)
    at isEditorBorderLine (extensions/open-tui/utils.ts:242)
    at findBottomBorderIndex (extensions/open-tui/utils.ts:250)
    at OpenTuiEditor.render (extensions/open-tui/editor.ts:207)
```

Reproduced in production (a local agent workspace running pi 0.3.x with pi-open-tui 0.3.3): every new pane died on first paint until patched.

## Root cause

`OpenTuiEditor.render()` calls `findBottomBorderIndex(baseLines)` with the output of `renderBase()`. When that array is sparse or shorter than expected (e.g. short/sparsely-populated line arrays), `lines[i]` can be `undefined`:

- `findBottomBorderIndex()` indexed with a non-null assertion (`lines[i]!`), bypassing the undefined case.
- `isEditorBorderLine()` then passed it straight into `stripAnsi(line)`, which throws on non-string input.

The crash surfaced for us via a partially-populated line array at first render; regardless of the specific producer, the border-scan loop should tolerate undefined entries.

## Fix

Two defensive guards in `extensions/open-tui/utils.ts`:

1. `findBottomBorderIndex()` — bind `lines[i]` to a local `const line` and skip when `undefined` (replaces the `lines[i]!` non-null assertion).
2. `isEditorBorderLine()` — early-return `false` for non-string input.

No behavior change for well-formed arrays; the function falls through to the existing `Math.max(0, lines.length - 1)` fallback.

## Verification

- `npm run typecheck` (tsc --noEmit): clean
- `npm test`: 81/81 pass
- The same patch has been running in a live pi 0.3.x installation since first applied; panes that previously crashed at startup now render normally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unexpected, non-text input when identifying editor border lines.
  * Improved bottom-border detection when line data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->