### PR TITLE
fix: detect Git repositories from nested directories

### DIFF
--- a/extensions/open-tui/git.ts
+++ b/extensions/open-tui/git.ts
@@ -1,6 +1,4 @@
 import { execFile } from "node:child_process";
-import { existsSync } from "node:fs";
-import { join } from "node:path";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
@@ -59,10 +57,6 @@ export async function readGitStatus(
 	cwd: string,
 	options: { readCommit?: boolean; readTag?: boolean; readCounts?: boolean } = {},
 ): Promise<GitStatus> {
-	if (!existsSync(join(cwd, ".git"))) {
-		return emptyGitStatus();
-	}
-
 	const stdout = await gitExec(
 		["status", "--porcelain=v1", "--branch", "--show-stash"],
 		cwd,

--- a/tests/footer.test.ts
+++ b/tests/footer.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -11,7 +12,7 @@ import type {
 import type { Component, TUI } from "@earendil-works/pi-tui";
 import { DEFAULT_CONFIG } from "../extensions/open-tui/config.ts";
 import { installFooter } from "../extensions/open-tui/footer.ts";
-import { emptyGitStatus } from "../extensions/open-tui/git.ts";
+import { emptyGitStatus, readGitStatus } from "../extensions/open-tui/git.ts";
 import { resolveGlyphs, runtimeSymbol } from "../extensions/open-tui/icons.ts";
 import { clearRuntimeCache, readRuntimeInfo } from "../extensions/open-tui/runtime.ts";
 import { getUsageTotals, invalidateUsageCache, type FooterState } from "../extensions/open-tui/state.ts";
@@ -20,6 +21,20 @@ import { fitSegmentsByPriority, truncateBranch, truncatePath } from "../extensio
 const theme = {
 	fg: (_color: string, text: string) => text,
 } as Theme;
+
+test("reads Git status from a nested repository directory", async () => {
+	const root = mkdtempSync(join(tmpdir(), "open-tui-git-"));
+	const nested = join(root, "packages", "app");
+	try {
+		execFileSync("git", ["init", "-b", "nested-repo-test"], { cwd: root });
+		execFileSync("git", ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "--allow-empty", "-m", "init"], { cwd: root });
+		mkdirSync(nested, { recursive: true });
+
+		assert.equal((await readGitStatus(nested)).branch, "nested-repo-test");
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
 
 test("branch truncation preserves the branch prefix", () => {
 	assert.equal(truncateBranch("fix/cwd-footer-truncation", 20), "fix/cwd-footer-tr...");


### PR DESCRIPTION
## Summary
- let Git discover repositories in parent directories
- restore footer Git info when Pi starts from a monorepo package
- add regression coverage for nested working directories

## Related issue
Closes #32

## Validation
- `npm test` — 82 passed
- `npm run typecheck` — passed

## Checklist
- [x] This PR contains one cohesive change; unrelated work is split into separate PRs.
- [x] I have added or updated tests where the change requires them.
- [x] I have run the relevant tests and checks.
- [x] I have updated documentation where needed. (No documentation change needed; this restores intended Git footer behavior.)