### PR TITLE
fix: find enclosing git repo when cwd has no .git

### DIFF
--- a/extensions/open-tui/git.ts
+++ b/extensions/open-tui/git.ts
@@ -1,6 +1,4 @@
 import { execFile } from "node:child_process";
-import { existsSync } from "node:fs";
-import { join } from "node:path";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
@@ -59,10 +57,6 @@ export async function readGitStatus(
 	cwd: string,
 	options: { readCommit?: boolean; readTag?: boolean; readCounts?: boolean } = {},
 ): Promise<GitStatus> {
-	if (!existsSync(join(cwd, ".git"))) {
-		return emptyGitStatus();
-	}
-
 	const stdout = await gitExec(
 		["status", "--porcelain=v1", "--branch", "--show-stash"],
 		cwd,


### PR DESCRIPTION
Fixes #32

## Problem

`readGitStatus` short-circuited with `existsSync(join(cwd, ".git"))` before running any git command. When Pi starts from a subdirectory that has no `.git` entry of its own (e.g. a package inside a monorepo), the footer showed no branch or status even though git itself resolves a repo in a parent directory.

## Change

Removed the `.git` existence pre-check so `readGitStatus` always runs `git status --porcelain=v1 --branch --show-stash` on the given `cwd`. Git discovers the enclosing worktree by its own rules, matching what `git status` shows from the same directory.

Directories outside any repo still fall back to the existing `gitExec` error path and return `emptyGitStatus()` — no behavior change there.



## Verification

- Manually verified in a throwaway repo: `readGitStatus` called from a nested directory without `.git` returns the parent repo's branch (`main`).
- `npm test` and `npm run typecheck` could not run in this workspace because `node_modules` is not installed (`ERR_MODULE_NOT_FOUND` / `TS2688` for `node` types); both failures are pre-existing environment issues, unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Git status retrieval now runs directly without requiring a local `.git` directory check.
  * Failed Git status commands continue to return an empty status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->