### PR TITLE
fix: keep the hardware cursor after /reload

### DIFF
--- a/extensions/open-tui/editor.ts
+++ b/extensions/open-tui/editor.ts
@@ -185,6 +185,11 @@ export class OpenTuiEditor extends CustomEditor {
 		const renderedLines = super.render(width);
 		if (this.cursorStyle === "block") return renderedLines;
 
+		// Pi re-applies settings.showHardwareCursor after session_start (/reload,
+		// /new, session switches). Non-block styles have no software cursor left to
+		// fall back on, so re-assert the hardware cursor instead of losing it.
+		if (!this.tui.getShowHardwareCursor()) configureCursor(this.tui, this.cursorStyle);
+
 		// A focused overlay suppresses the editor's cursor marker. Preserve its
 		// position only for the live settings preview, then clear it on refocus.
 		let cursorMarker = this.previewHardwareCursor && !this.focused ? CURSOR_MARKER : "";

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -251,11 +251,11 @@ test("keeps a hardware cursor after Pi re-applies its runtime settings", () => {
 	hostTui.setShowHardwareCursor(false);
 	cursorEvents.length = 0;
 	(hostTui as unknown as { doRender(): void }).doRender();
+	assert.equal(cursorEvents.at(-1), "show");
 
 	assert.ok(
 		editor.render(40).every((line) => !line.includes("\x1b[7m")),
 		"software cursor stays stripped",
 	);
-	assert.equal(cursorEvents.at(-1), "show");
 	hostTui.stop();
 });

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -88,6 +88,7 @@ test("uses the terminal hardware cursor for non-block styles", () => {
 				rows: 24,
 				write: (data: string) => writes.push(data),
 			},
+			getShowHardwareCursor: () => hardwareCursor === true,
 			setShowHardwareCursor: (enabled: boolean) => {
 				hardwareCursor = enabled;
 			},
@@ -220,4 +221,41 @@ test("frame recolors via borderColor (bash mode / thinking level hook)", () => {
 	assert.ok(body.startsWith("│") && body.endsWith("│"), `body rails: ${body!}`);
 	assert.ok(painted.some((text) => text.startsWith("╭")), "left top corner bypassed borderColor");
 	assert.ok(painted.some((text) => text.endsWith("╮")), "right top corner bypassed borderColor");
+});
+
+test("keeps a hardware cursor after Pi re-applies its runtime settings", () => {
+	const cursorEvents: string[] = [];
+	const terminal = {
+		columns: 80,
+		rows: 24,
+		kittyProtocolActive: false,
+		start() {},
+		stop() {},
+		write() {},
+		hideCursor: () => cursorEvents.push("hide"),
+		showCursor: () => cursorEvents.push("show"),
+	} as unknown as Terminal;
+	const hostTui = new TuiMainScreen(terminal, false);
+	const editor = new OpenTuiEditor(
+		hostTui,
+		editorTheme,
+		{ matches: () => false } as unknown as KeybindingsManager,
+		"bar",
+	);
+	hostTui.addChild(editor);
+	hostTui.setFocus(editor);
+
+	// Pi re-applies settings.showHardwareCursor after session_start on /reload,
+	// which would leave no cursor at all: the software cursor is stripped for
+	// non-block styles.
+	hostTui.setShowHardwareCursor(false);
+	cursorEvents.length = 0;
+	(hostTui as unknown as { doRender(): void }).doRender();
+
+	assert.ok(
+		editor.render(40).every((line) => !line.includes("\x1b[7m")),
+		"software cursor stays stripped",
+	);
+	assert.equal(cursorEvents.at(-1), "show");
+	hostTui.stop();
 });


### PR DESCRIPTION
Fixes #34.

`OpenTuiEditor` strips Pi's software cursor for the `bar` and `underline` styles and relies on the hardware cursor. Pi's `applyRuntimeSettings()` re-applies `settings.showHardwareCursor` (default `false`) *after* `session_start` on `/reload`, so the cursor vanished entirely.

`renderBase()` now re-asserts the hardware cursor (and the DECSCUSR shape) whenever it is off and the style is not `block`, so any host-side reset self-heals on the next frame — covering `/reload`, `/new` and session switches with one guard.

Regression test added: it fails on `main` (`'hide' !== 'show'`) and passes with the fix. `npm test` (83 passing) and `npm run typecheck` are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where bar and other non-block cursor styles could disappear after reloading, starting a new session, or switching sessions.
  * Hardware cursors now remain visible when runtime settings are reapplied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->