### PR TITLE
feat: add hostname footer segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Run `/open-tui` to open the settings dialog. It provides **General**, **Appearan
   },
   "footerSegments": {
     "cwd": true,
+    "hostname": false,
     "sessionName": false,
     "gitBranch": true,
     "gitStatus": true,
@@ -103,7 +104,7 @@ Key options:
 | `telemetry` | Boolean flags | Enables telemetry and its individual measurements |
 | `thinkingPeek.lines` | `0`, `1`, `2` | Off, one-line, or two-line hidden thinking preview |
 
-`sessionName` appears only when the session has a name. `gitCommit` shows the short hash and tag in detached HEAD state. Disabling `extensionStatuses` hides the entire extension status line, including MCP status.
+`sessionName` appears only when the session has a name. `hostname` shows the short host name (first label of the machine's host name, e.g. `mba` from `mba.example.com`) with a server icon. `gitCommit` shows the short hash and tag in detached HEAD state. Disabling `extensionStatuses` hides the entire extension status line, including MCP status.
 
 Fullscreen wheel speed uses an isolated compatibility shim for Pi 0.84.2's runtime field because Pi does not yet expose a public setter. On Pi versions without a compatible field, the setting is ignored and Pi's default scrolling remains active.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -66,6 +66,7 @@ pi -e npm:pi-open-tui
   },
   "footerSegments": {
     "cwd": true,
+    "hostname": false,
     "sessionName": false,
     "gitBranch": true,
     "gitStatus": true,
@@ -103,7 +104,7 @@ pi -e npm:pi-open-tui
 | `telemetry` | 布尔开关 | 控制遥测总开关和各项指标 |
 | `thinkingPeek.lines` | `0`、`1`、`2` | 关闭、单行或双行思考预览 |
 
-`sessionName` 仅在会话有名称时显示；`gitCommit` 会在 detached HEAD 状态下显示短哈希和标签；关闭 `extensionStatuses` 会隐藏整行扩展状态，其中也包括 MCP 状态。
+`sessionName` 仅在会话有名称时显示；`hostname` 会显示主机名的短名称（主机名的第一个标签，例如从 `mba.example.com` 显示为 `mba`），并使用服务器图标；`gitCommit` 会在 detached HEAD 状态下显示短哈希和标签；关闭 `extensionStatuses` 会隐藏整行扩展状态，其中也包括 MCP 状态。
 
 全屏滚轮速度通过隔离的兼容层写入 Pi 0.84.2 的运行时字段，因为 Pi 尚未提供公开 setter。若后续 Pi 版本不再包含兼容字段，该设置会被忽略并继续使用 Pi 的默认滚动行为。
 

--- a/extensions/open-tui/config.ts
+++ b/extensions/open-tui/config.ts
@@ -15,6 +15,7 @@ export type { IconMode } from "./icons.ts";
 
 export interface FooterSegments {
 	cwd: boolean;
+	hostname: boolean;
 	sessionName: boolean;
 	gitBranch: boolean;
 	gitStatus: boolean;
@@ -69,6 +70,7 @@ export const DEFAULT_CONFIG: OpenTuiConfig = {
 	},
 	footerSegments: {
 		cwd: true,
+		hostname: false,
 		sessionName: false,
 		gitBranch: true,
 		gitStatus: true,

--- a/extensions/open-tui/footer.ts
+++ b/extensions/open-tui/footer.ts
@@ -1,4 +1,5 @@
 import type { ExtensionContext, Theme, ThemeColor } from "@earendil-works/pi-coding-agent";
+import { hostname as osHostname } from "node:os";
 import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import type { OpenTuiConfig } from "./config.ts";
 import type { IconGlyphs } from "./icons.ts";
@@ -245,6 +246,15 @@ export function installFooter(
 							return `${cwdPrefix}${accent(truncatePath(basenamePath(cwd), pathWidth))}`;
 						},
 					});
+				}
+				if (segments.hostname) {
+					const shortHost = osHostname().split(".")[0];
+					if (shortHost) {
+						leftParts.push({
+							text: `${theme.fg("dim", glyphs.host)} ${theme.fg("accent", shortHost)}`,
+							priority: 1,
+						});
+					}
 				}
 				if (segments.sessionName) {
 					const sessionName = ctx.sessionManager.getSessionName();

--- a/extensions/open-tui/footer.ts
+++ b/extensions/open-tui/footer.ts
@@ -26,6 +26,10 @@ import {
 import type { FooterState, ModelMeta, UsageTotals } from "./state.ts";
 import { getUsageTotals } from "./state.ts";
 
+export function shortHostname(hostname: string): string {
+	return hostname.split(".")[0] ?? "";
+}
+
 function renderBar(theme: Theme, pct: number, barWidth: number, ascii: boolean): string {
 	const filled = Math.max(0, Math.min(barWidth, Math.round((pct / 100) * barWidth)));
 	const empty = barWidth - filled;
@@ -248,7 +252,7 @@ export function installFooter(
 					});
 				}
 				if (segments.hostname) {
-					const shortHost = osHostname().split(".")[0];
+					const shortHost = shortHostname(osHostname());
 					if (shortHost) {
 						leftParts.push({
 							text: `${theme.fg("dim", glyphs.host)} ${theme.fg("accent", shortHost)}`,

--- a/extensions/open-tui/icons.ts
+++ b/extensions/open-tui/icons.ts
@@ -2,6 +2,7 @@ export type IconMode = "auto" | "nerd" | "ascii";
 
 export interface IconGlyphs {
 	cwd: string;
+	host: string;
 	session: string;
 	git: string;
 	working: string;
@@ -31,6 +32,7 @@ export interface IconGlyphs {
 
 const NERD_GLYPHS: IconGlyphs = {
 	cwd: "",
+	host: "",
 	session: "",
 	git: "",
 	working: "",
@@ -64,6 +66,7 @@ const NERD_GLYPHS: IconGlyphs = {
 // avoid collisions with the git-status set {= S ! A ? r x ^ v}.
 const ASCII_GLYPHS: IconGlyphs = {
 	cwd: "@",
+	host: "h",
 	session: "s",
 	git: "*",
 	working: "o",

--- a/extensions/open-tui/settings-command.ts
+++ b/extensions/open-tui/settings-command.ts
@@ -39,6 +39,7 @@ const COPY = {
 			cursorStyle: "Cursor style",
 			iconMode: "Icon mode",
 			cwd: "CWD",
+			hostname: "Hostname",
 			sessionName: "Session name",
 			gitBranch: "Git branch",
 			gitStatus: "Git status",
@@ -76,6 +77,7 @@ const COPY = {
 			cursorStyle: "光标样式",
 			iconMode: "图标模式",
 			cwd: "当前目录",
+			hostname: "主机名",
 			sessionName: "会话名",
 			gitBranch: "Git 分支",
 			gitStatus: "Git 状态",
@@ -196,6 +198,7 @@ function buildSegmentsItems(config: OpenTuiConfig, copy: SettingsCopy): SettingI
 	const flag = (value: boolean) => value ? copy.values.on : copy.values.off;
 	return [
 		{ id: "cwd", label: copy.labels.cwd, currentValue: flag(segs.cwd) },
+		{ id: "hostname", label: copy.labels.hostname, currentValue: flag(segs.hostname) },
 		{ id: "sessionName", label: copy.labels.sessionName, currentValue: flag(segs.sessionName) },
 		{ id: "gitBranch", label: copy.labels.gitBranch, currentValue: flag(segs.gitBranch) },
 		{ id: "gitStatus", label: copy.labels.gitStatus, currentValue: flag(segs.gitStatus) },
@@ -374,7 +377,7 @@ class SettingsUi implements SettingsUiHandle {
 				description: editing || this.compact ? undefined : item.currentValue,
 			} as SelectItem;
 		});
-		this.selectList = new SelectList(items, Math.min(items.length, 10), {
+		this.selectList = new SelectList(items, Math.min(items.length, 12), {
 			selectedPrefix: (t) => this.theme.fg("accent", t),
 			selectedText: (t) => this.theme.fg("accent", t),
 			description: (t) => this.theme.fg("muted", t),

--- a/tests/footer.test.ts
+++ b/tests/footer.test.ts
@@ -11,7 +11,7 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import type { Component, TUI } from "@earendil-works/pi-tui";
 import { DEFAULT_CONFIG } from "../extensions/open-tui/config.ts";
-import { installFooter } from "../extensions/open-tui/footer.ts";
+import { installFooter, shortHostname } from "../extensions/open-tui/footer.ts";
 import { emptyGitStatus, readGitStatus } from "../extensions/open-tui/git.ts";
 import { resolveGlyphs, runtimeSymbol } from "../extensions/open-tui/icons.ts";
 import { clearRuntimeCache, readRuntimeInfo } from "../extensions/open-tui/runtime.ts";
@@ -542,15 +542,22 @@ function renderFooterWithHost(opts: {
 	return component.render(width).join("\n");
 }
 
+test("short hostname keeps the first label across host name formats", () => {
+	assert.equal(shortHostname("mba.example.com"), "mba");
+	assert.equal(shortHostname("OldSun_Laptop"), "OldSun_Laptop");
+	assert.equal(shortHostname(""), "");
+});
+
 test("footer shows the short host name next to cwd when enabled", () => {
-	const expectedHost = hostname().split(".")[0];
+	const expectedHost = shortHostname(hostname());
 	const out = renderFooterWithHost();
-	assert.ok(out.includes(expectedHost), `missing short host name\n${out}`);
+	assert.ok(out.includes(`${resolveGlyphs("ascii").host} ${expectedHost}`), `missing short host name\n${out}`);
 });
 
 test("footer hides host name when footerSegments.hostname is false", () => {
+	const expectedHost = shortHostname(hostname());
 	const out = renderFooterWithHost({ hostnameEnabled: false });
-	assert.ok(!out.includes(hostname().split(".")[0]), `should be hidden when disabled\n${out}`);
+	assert.ok(!out.includes(`${resolveGlyphs("ascii").host} ${expectedHost}`), `should be hidden when disabled\n${out}`);
 });
 
 test("host name uses matching glyph in nerd and ascii modes", () => {

--- a/tests/footer.test.ts
+++ b/tests/footer.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { hostname, tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import type {
@@ -171,6 +171,7 @@ test("narrow footer sheds the context bar before left segments", () => {
 test("both icon modes provide every footer semantic", () => {
 	const keys = [
 		"cwd",
+		"host",
 		"session",
 		"git",
 		"working",
@@ -488,4 +489,73 @@ test("session name uses matching glyph in nerd and ascii modes", () => {
 	assert.ok(asciiOut.includes(resolveGlyphs("ascii").session), `ascii glyph missing\n${asciiOut}`);
 	const nerdOut = renderFooterWithSession({ mode: "nerd", sessionName: "sess" });
 	assert.ok(nerdOut.includes(resolveGlyphs("nerd").session), `nerd glyph missing\n${nerdOut}`);
+});
+
+function renderFooterWithHost(opts: {
+	mode?: "nerd" | "ascii";
+	hostnameEnabled?: boolean;
+	width?: number;
+} = {}): string {
+	const { mode = "ascii", hostnameEnabled = true, width = 160 } = opts;
+	let footerFactory: NonNullable<Parameters<ExtensionContext["ui"]["setFooter"]>[0]> | undefined;
+	const ctx = {
+		model: { provider: "openai", contextWindow: 1_000 },
+		ui: {
+			setFooter(factory: typeof footerFactory) {
+				footerFactory = factory;
+			},
+		},
+		sessionManager: {
+			getCwd: () => "/work/project",
+			getEntries: () => [],
+			getSessionName: () => undefined,
+		},
+		getContextUsage: () => ({ tokens: 0, contextWindow: 1_000, percent: 0 }),
+	} as unknown as ExtensionContext;
+	const config = structuredClone(DEFAULT_CONFIG);
+	config.icons.mode = mode;
+	config.footerSegments.hostname = hostnameEnabled;
+	const state: FooterState = {
+		git: emptyGitStatus(),
+		runtime: null,
+		sessionStartEpoch: Date.now(),
+		workingSince: undefined,
+		lastDoneIn: undefined,
+	};
+	installFooter(
+		ctx,
+		() => state,
+		() => config,
+		() => ({ provider: "OpenAI", model: "gpt-5", effort: "off" }),
+		{ setRequestRender() {}, scheduleGitRefresh() {} },
+	);
+	assert.ok(footerFactory);
+	const footerData = {
+		onBranchChange: () => () => {},
+		getExtensionStatuses: () => new Map(),
+	} as unknown as ReadonlyFooterDataProvider;
+	const component = footerFactory(
+		{ requestRender() {} } as TUI,
+		theme,
+		footerData,
+	) as Component;
+	return component.render(width).join("\n");
+}
+
+test("footer shows the short host name next to cwd when enabled", () => {
+	const expectedHost = hostname().split(".")[0];
+	const out = renderFooterWithHost();
+	assert.ok(out.includes(expectedHost), `missing short host name\n${out}`);
+});
+
+test("footer hides host name when footerSegments.hostname is false", () => {
+	const out = renderFooterWithHost({ hostnameEnabled: false });
+	assert.ok(!out.includes(hostname().split(".")[0]), `should be hidden when disabled\n${out}`);
+});
+
+test("host name uses matching glyph in nerd and ascii modes", () => {
+	const asciiOut = renderFooterWithHost({ mode: "ascii" });
+	assert.ok(asciiOut.includes(resolveGlyphs("ascii").host), `ascii glyph missing\n${asciiOut}`);
+	const nerdOut = renderFooterWithHost({ mode: "nerd" });
+	assert.ok(nerdOut.includes(resolveGlyphs("nerd").host), `nerd glyph missing\n${nerdOut}`);
 });

--- a/tests/settings-command.test.ts
+++ b/tests/settings-command.test.ts
@@ -316,6 +316,18 @@ test("supports localized settings and keyboard shortcuts", async () => {
 	assert.equal(reopened.isClosed(), true);
 });
 
+test("configures the hostname footer segment", async () => {
+	const settings = await openSettings();
+	settings.component.handleInput("\x1b[C");
+	settings.component.handleInput("\x1b[C");
+	settings.component.handleInput("\x1b[B");
+	assert.match(selectedLine(settings.component), /Hostname/);
+
+	settings.component.handleInput(" ");
+	assert.equal(settings.getConfig().footerSegments.hostname, true);
+	assert.match(selectedLine(settings.component), /Hostname/);
+});
+
 test("configures the extension status line with Space", async () => {
 	const settings = await openSettings();
 	settings.component.handleInput("\x1b[C");

--- a/tests/settings-command.test.ts
+++ b/tests/settings-command.test.ts
@@ -255,6 +255,7 @@ test("keeps the changed setting selected", async () => {
 	settings.component.handleInput("\t");
 	settings.component.handleInput("\x1b[B");
 	settings.component.handleInput("\x1b[B");
+	settings.component.handleInput("\x1b[B");
 	assert.match(selectedLine(settings.component), /Git branch/);
 
 	settings.component.handleInput("\r");
@@ -267,6 +268,7 @@ test("remembers the selection for each tab", async () => {
 
 	settings.component.handleInput("\t");
 	settings.component.handleInput("\t");
+	settings.component.handleInput("\x1b[B");
 	settings.component.handleInput("\x1b[B");
 	settings.component.handleInput("\x1b[B");
 	settings.component.handleInput("\t");
@@ -318,7 +320,7 @@ test("configures the extension status line with Space", async () => {
 	const settings = await openSettings();
 	settings.component.handleInput("\x1b[C");
 	settings.component.handleInput("\x1b[C");
-	for (let i = 0; i < 9; i++) settings.component.handleInput("\x1b[B");
+	for (let i = 0; i < 10; i++) settings.component.handleInput("\x1b[B");
 	assert.match(selectedLine(settings.component), /Extension status line/);
 
 	settings.component.handleInput(" ");


### PR DESCRIPTION
## Summary

Adds an opt-in **hostname** footer segment showing the short host name (first label of the machine's host name, e.g. `mba` from `mba.example.com`) with a server icon. Rendered next to the CWD segment.

## Changes

- **config** – new `footerSegments.hostname` flag, default `false`; existing configs unaffected (deepMerge backfills the default)
- **footer** – renders next to CWD when enabled (priority aligned with the working-timer); short host = `os.hostname().split(".")[0]`, matching `hostname -s` on macOS/Linux; empty host handled
- **icons** – `host` glyph: Nerd Font U+F233 (fa-server), ASCII `h`
- **settings** – toggleable from the `/open-tui` Footer tab (en "Hostname" / zh "主机名"); settings list height raised 10→12 so the new row stays visible
- **docs** – README config example + segment note
- **tests** – glyph coverage for both icon modes, render/visibility/glyph tests for the segment; settings navigation tests updated for the new row

## Testing

Full suite: `npm test` → 85/85 pass. Feature also exercised live in the author's pi TUI footer (segment visible, toggles correctly).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional hostname footer segment that displays the machine’s short hostname with a host icon.
  - Added a Hostname toggle in the settings interface.
  - Added Nerd Font and ASCII fallback icons for hostname display.
  - Hostname display is disabled by default and appears only when enabled and available.

- **Documentation**
  - Documented the hostname footer configuration option and its short-hostname format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->